### PR TITLE
Undefined name: 'false' --> 'False' in HueEmulator3.py

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1457,7 +1457,7 @@ class S(BaseHTTPRequestHandler):
                                 any_on = True
                             else:
                                 all_on = False
-                        self._set_end_headers(bytes(json.dumps({"name":"Group 0","lights": [l for l in bridge_config["lights"]],"sensors": [s for s in bridge_config["sensors"]],"type":"LightGroup","state":{"all_on":all_on,"any_on":any_on},"recycle":false,"action":{"on":false,"alert":"none"}},separators=(',', ':')), "utf8"))
+                        self._set_end_headers(bytes(json.dumps({"name":"Group 0","lights": [l for l in bridge_config["lights"]],"sensors": [s for s in bridge_config["sensors"]],"type":"LightGroup","state":{"all_on":all_on,"any_on":any_on},"recycle":False,"action":{"on":False,"alert":"none"}},separators=(',', ':')), "utf8"))
                     elif url_pices[3] == "info":
                         self._set_end_headers(bytes(json.dumps(bridge_config["capabilities"][url_pices[4]],separators=(',', ':')), "utf8"))
                     else:


### PR DESCRIPTION
__false__ is an _undefined name_ in this context which has the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/diyhue/diyHue on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./BridgeEmulator/HueEmulator3.py:1460:250: F821 undefined name 'false'
                        self._set_end_headers(bytes(json.dumps({"name":"Group 0","lights": [l for l in bridge_config["lights"]],"sensors": [s for s in bridge_config["sensors"]],"type":"LightGroup","state":{"all_on":all_on,"any_on":any_on},"recycle":false,"action":{"on":false,"alert":"none"}},separators=(',', ':')), "utf8"))
                                                                                                                                                                                                                                                         ^
./BridgeEmulator/HueEmulator3.py:1460:271: F821 undefined name 'false'
                        self._set_end_headers(bytes(json.dumps({"name":"Group 0","lights": [l for l in bridge_config["lights"]],"sensors": [s for s in bridge_config["sensors"]],"type":"LightGroup","state":{"all_on":all_on,"any_on":any_on},"recycle":false,"action":{"on":false,"alert":"none"}},separators=(',', ':')), "utf8"))
                                                                                                                                                                                                                                                                              ^
2     F821 undefined name 'false'
2
```