### PR TITLE
Update HueEmulator3.py

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -91,7 +91,7 @@ sensors_state = {}
 def updateConfig():
     for sensor in bridge_config["deconz"]["sensors"].keys():
         if "modelid" not in bridge_config["deconz"]["sensors"][sensor]:
-            bridge_config["deconz"]["sensors"]["modelid"] = bridge_config["sensors"][bridge_config["deconz"]["sensors"][sensor]["bridgeid"]]["modelid"]
+            bridge_config["deconz"]["sensors"][sensor]["modelid"] = bridge_config["sensors"][bridge_config["deconz"]["sensors"][sensor]["bridgeid"]]["modelid"]
         if bridge_config["deconz"]["sensors"][sensor]["modelid"] == "TRADFRI motion sensor":
             if "lightsensor" not in bridge_config["deconz"]["sensors"][sensor]:
                 bridge_config["deconz"]["sensors"][sensor]["lightsensor"] = "internal"


### PR DESCRIPTION
Fixed issue of new remotes not getting correctly added.
- When a new tradfri remote is added to deconz, the hue emulator stops working after reboot. Reason for that is, that the modelid is not getting set correctly