### PR TITLE
add manufacturername to tradfri scan on new lights

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -909,7 +909,7 @@ def scanTradfri():
                     #register new tradfri lightdevice_id
                     logging.info("register tradfi light " + device_parameters["9001"])
                     new_light_id = nextFreeId(bridge_config, "lights")
-                    bridge_config["lights"][new_light_id] = {"state": {"on": False, "bri": 200, "hue": 0, "sat": 0, "xy": [0.0, 0.0], "ct": 461, "alert": "none", "effect": "none", "colormode": "ct", "reachable": True}, "type": "Extended color light", "name": device_parameters["9001"], "uniqueid": "1234567" + str(device), "modelid": "LLM010", "swversion": "66009461"}
+                    bridge_config["lights"][new_light_id] = {"state": {"on": False, "bri": 200, "hue": 0, "sat": 0, "xy": [0.0, 0.0], "ct": 461, "alert": "none", "effect": "none", "colormode": "ct", "reachable": True}, "type": "Extended color light", "name": device_parameters["9001"], "uniqueid": "1234567" + str(device), "modelid": "LLM010", "swversion": "66009461", "manufacturername": "Philips"}
                     new_lights.update({new_light_id: {"name": device_parameters["9001"]}})
                     bridge_config["lights_address"][new_light_id] = {"device_id": device, "preshared_key": bridge_config["tradfri"]["psk"], "identity": bridge_config["tradfri"]["identity"], "ip": bridge_config["tradfri"]["ip"], "protocol": "ikea_tradfri"}
         return lights_found


### PR DESCRIPTION
hi, i fixed that bug in hue bridge itself a couple of days ago, but as i wanted to integrate my ikea lights through the hue bridge instead of tradfri directly in home assistant (tradfri is buggy in home assistant), home assistant was picky about the manufacturername. i could fix this by manually adding the manufacturername to my config.json. this PR will just add the manufacturername with the default "Philips" value for new tradfri lights so they should work regardless.