### PR TITLE
Illegal float value in MiLight field "ct" changed to int

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -867,7 +867,7 @@ def syncWithLights(): #update Hue Bridge lights states
                         bridge_config["lights"][light]["state"]["bri"] = light_data["brightness"]
                     if "color_temp" in light_data:
                         bridge_config["lights"][light]["state"]["colormode"] = "ct"
-                        bridge_config["lights"][light]["state"]["ct"] = light_data["color_temp"] * 1.6
+                        bridge_config["lights"][light]["state"]["ct"] = int(light_data["color_temp"] * 1.6)
                     elif "bulb_mode" in light_data and light_data["bulb_mode"] == "color":
                         bridge_config["lights"][light]["state"]["colormode"] = "hs"
                         bridge_config["lights"][light]["state"]["hue"] = light_data["hue"] * 180


### PR DESCRIPTION
Caused Hue Essentials to crash: 

01-03 18:27:00.268 11470 11587 W System.err: 	at java.lang.Thread.run(Thread.java:784)
01-03 18:27:00.268 11470 11587 W System.err:   ComposedException 1 :
01-03 18:27:00.268 11470 11587 W System.err: 	java.lang.NumberFormatException: Expected an int but was 244.8 at line 1 column 3985 path $.lights.10.state.ct
