### PR TITLE
prevent form/input from submit on enter key

### DIFF
--- a/BridgeEmulator/debug/clip.html
+++ b/BridgeEmulator/debug/clip.html
@@ -44,7 +44,7 @@
         <form name="commandform">
             <h1>CLIP API Debugger</h1>
             <h2>URL:</h2>
-            <input name="commandurl" type="text" size="60" value="/api/1234/">
+            <input id="commandurl" name="commandurl" type="text" size="60" value="/api/1234/">
             <div id="buttons">
                 <button type="button" onclick="getHTML('GET')">GET</button>
                 <button type="button" onclick="getHTML('PUT')">PUT</button>
@@ -60,6 +60,12 @@
 </html>
 
 <script language="JavaScript">
+document.getElementById('commandurl').addEventListener('keypress', function (event) {
+    if (event.keyCode == 13) {
+        getHTML('GET');
+        event.preventDefault();
+    }
+});
 function getHTML(command)
 {
     if (window.XMLHttpRequest)


### PR DESCRIPTION
This should prevent the input from submitting when it has focus and the enter key is pressed. This caused an error response because the HueEmulator3.py script doesen't parsed the resulting url correctly. Now it performs a GET request on hitting enter.