### PR TITLE
Fixed Milight exception "name 'convert_xy' is not defined"

### DIFF
--- a/BridgeEmulator/functions/lightRequest.py
+++ b/BridgeEmulator/functions/lightRequest.py
@@ -1,5 +1,6 @@
 import logging, json
 from functions.request import sendRequest
+from functions.colors import convert_rgb_xy, convert_xy  
 from subprocess import check_output
 from protocols import protocols
 from datetime import datetime


### PR DESCRIPTION
Milight lamps did not change colors because of this bug

```
Mär 27 17:45:55 osmc HueEmulator3.py[3268]: Traceback (most recent call last):
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/usr/lib/python3.5/socketserver.py", line 625, in process_request_thread
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     self.finish_request(request, client_address)
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     self.RequestHandlerClass(request, client_address, self)
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     self.handle()
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/usr/lib/python3.5/http/server.py", line 424, in handle
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     self.handle_one_request()
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     method()
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/opt/hue-emulator/HueEmulator3.py", line 1455, in do_PUT
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     sendLightRequest(url_pices[4], put_dictionary, bridge_config["lights"], bridge_config["lights_address"])
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:   File "/opt/hue-emulator/functions/lightRequest.py", line 75, in sendLightRequest
Mär 27 17:45:55 osmc HueEmulator3.py[3268]:     (payload["color"]["r"], payload["color"]["g"], payload["color"]["b"]) = convert_xy(value[0], value[1], lights[light]["state"]["bri"])
Mär 27 17:45:55 osmc HueEmulator3.py[3268]: NameError: name 'convert_xy' is not defined
```