### PR TITLE
fix: light-discovery: checking if json is valid.

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -633,70 +633,73 @@ def scan_for_lights(): #scan for ESP8266 lights and strips
             response = requests.get("http://" + ip + "/detect", timeout=3)
             if response.status_code == 200:
                 # XXX JSON validation
-                device_data = json.loads(response.text)
-                logging.info(pretty_json(device_data))
-                if "modelid" in device_data:
-                    logging.info(ip + " is " + device_data['name'])
-                    if "protocol" in device_data:
-                        protocol = device_data["protocol"]
-                    else:
-                        protocol = "native"
+                try:
+                    device_data = json.loads(response.text)
+                    logging.info(pretty_json(device_data))
+                    if "modelid" in device_data:
+                        logging.info(ip + " is " + device_data['name'])
+                        if "protocol" in device_data:
+                            protocol = device_data["protocol"]
+                        else:
+                            protocol = "native"
 
-                    # Get number of lights
-                    lights = 1
-                    if "lights" in device_data:
-                        lights = device_data["lights"]
+                        # Get number of lights
+                        lights = 1
+                        if "lights" in device_data:
+                            lights = device_data["lights"]
 
-                    # Add each light to config
-                    logging.info("Add new light: " + device_data["name"])
-                    for x in range(1, lights + 1):
-                        light = find_light_in_config_from_mac_and_nr(bridge_config,
-                                device_data['mac'], x)
+                        # Add each light to config
+                        logging.info("Add new light: " + device_data["name"])
+                        for x in range(1, lights + 1):
+                            light = find_light_in_config_from_mac_and_nr(bridge_config,
+                                    device_data['mac'], x)
 
-                        # Try to find light in existing config
-                        if light:
-                            logging.info("Updating old light: " + device_data["name"])
-                            # Light found, update config
-                            light_address = bridge_config["lights_address"][light]
-                            light_address["ip"] = ip
-                            light_address["protocol"] = protocol
-                            if "version" in device_data:
-                                light_address.update({
-                                    "version": device_data["version"],
-                                    "type": device_data["type"],
-                                    "name": device_data["name"]
-                                })
-                            continue
+                            # Try to find light in existing config
+                            if light:
+                                logging.info("Updating old light: " + device_data["name"])
+                                # Light found, update config
+                                light_address = bridge_config["lights_address"][light]
+                                light_address["ip"] = ip
+                                light_address["protocol"] = protocol
+                                if "version" in device_data:
+                                    light_address.update({
+                                        "version": device_data["version"],
+                                        "type": device_data["type"],
+                                        "name": device_data["name"]
+                                    })
+                                continue
 
-                        new_light_id = nextFreeId(bridge_config, "lights")
+                            new_light_id = nextFreeId(bridge_config, "lights")
 
-                        light_name = generate_light_name(device_data['name'], x)
+                            light_name = generate_light_name(device_data['name'], x)
 
-                        # Construct the configuration for this light from a few sources, in order of precedence
-                        # (later sources override earlier ones).
-                        # Global defaults
-                        new_light = {
-                            "manufacturername": "Philips",
-                            "uniqueid": generate_unique_id(),
-                        }
-                        # Defaults for this specific modelid
-                        if device_data["modelid"] in light_types:
-                            new_light.update(light_types[device_data["modelid"]])
-                            # Make sure to make a copy of the state dictionary so we don't share the dictionary
-                            new_light['state'] = light_types[device_data["modelid"]]['state'].copy()
-                        # Overrides from the response JSON
-                        new_light["modelid"] = device_data["modelid"]
-                        new_light["name"] = light_name
+                            # Construct the configuration for this light from a few sources, in order of precedence
+                            # (later sources override earlier ones).
+                            # Global defaults
+                            new_light = {
+                                "manufacturername": "Philips",
+                                "uniqueid": generate_unique_id(),
+                            }
+                            # Defaults for this specific modelid
+                            if device_data["modelid"] in light_types:
+                                new_light.update(light_types[device_data["modelid"]])
+                                # Make sure to make a copy of the state dictionary so we don't share the dictionary
+                                new_light['state'] = light_types[device_data["modelid"]]['state'].copy()
+                            # Overrides from the response JSON
+                            new_light["modelid"] = device_data["modelid"]
+                            new_light["name"] = light_name
 
-                        # Add the light to new lights, and to bridge_config (in two places)
-                        new_lights[new_light_id] = {"name": light_name}
-                        bridge_config["lights"][new_light_id] = new_light
-                        bridge_config["lights_address"][new_light_id] = {
-                            "ip": ip,
-                            "light_nr": x,
-                            "protocol": protocol,
-                            "mac": device_data["mac"]
-                        }
+                            # Add the light to new lights, and to bridge_config (in two places)
+                            new_lights[new_light_id] = {"name": light_name}
+                            bridge_config["lights"][new_light_id] = new_light
+                            bridge_config["lights_address"][new_light_id] = {
+                                "ip": ip,
+                                "light_nr": x,
+                                "protocol": protocol,
+                                "mac": device_data["mac"]
+                            }
+                except ValueError:  
+                    logging.info('Decoding JSON from %s has failed', ip)
         except Exception as e:
             logging.info("ip %s is unknown device: %s", ip, e)
             raise


### PR DESCRIPTION
prevents crashing if some non-light device like routers or servers answer on `http://<ipoflight>/detect`

background: my ISP modem answers by calling http://192.168.0.1/detect with its login page which leads to a crash in 

`def scan_for_lights():`

see issue: https://github.com/diyhue/diyHue/issues/166