### PR TITLE
Wrap ifname to bytes in struct pack in network_openwrt

### DIFF
--- a/BridgeEmulator/functions/network_OpenWrt.py
+++ b/BridgeEmulator/functions/network_OpenWrt.py
@@ -8,7 +8,7 @@ if os.name != "nt":
     def get_interface_ip(ifname):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         return socket.inet_ntoa(fcntl.ioctl(s.fileno(), 0x8915, struct.pack('256s',
-                                ifname[:15]))[20:24])
+                                bytes(ifname[:15], 'utf-8')))[20:24])
 
 def getIpAddress():
     ip = socket.gethostbyname(socket.gethostname())


### PR DESCRIPTION
This PR is related to the bug #247 

It wraps the ifname array to a UTF-8 byte array required by struct.pack.