### PR TITLE
Use the proper entertain-srv version depending on CPU architecture an…

### DIFF
--- a/BridgeEmulator/install_openwrt.sh
+++ b/BridgeEmulator/install_openwrt.sh
@@ -38,7 +38,7 @@ wait
 cd /opt/hue-emulator
 git clone https://github.com/ARMmbed/mbedtls.git
 wait
-cp /opt/hue-emultor/ssl_server2_diyhue.c /opt/hue-emultor/mbedtls
+cp /opt/hue-emulator/ssl_server2_diyhue.c /opt/hue-emulator/mbedtls
 cd /opt/hue-emulator/mbedtls
 export CC=gcc && make no_test
 wait

--- a/BridgeEmulator/update_openwrt.sh
+++ b/BridgeEmulator/update_openwrt.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# To build entertainment srv from source use:
+# export COMPILE_ENTERTAIN_SRV=true
+
 echo -e "\033[32m Disable startup service.\033[0m"
 /etc/init.d/hueemulatorWrt-service disable
 echo -e "\033[32m Create directory for backup configuration.\033[0m"
@@ -40,12 +43,66 @@ cp /tmp/diyHue-config/cert.pem.bak /opt/hue-emulator/cert.pem
 cp default-config.json /opt/hue-emulator/default-config.json
 cp -r web-ui /opt/hue-emulator/
 cp -r functions protocols debug /opt/hue-emulator/
-cp entertainment-mips /opt/hue-emulator/entertain-srv
+
+if [ "$COMPILE_ENTERTAIN_SRV" = "true" ]
+then
+
+	# Build from Source
+	opkg update
+	wait
+	opkg install gcc make automake ca-bundle git git-http nano nmap python3 python3-pip python3-setuptools openssl-util curl unzip coap-client
+	wait
+	cd /opt/tmp/diyHue*/BridgeEmulator
+	mv ssl_server2_diyhue.c /opt/hue-emulator/
+	cd /opt/hue-emulator
+	wait
+	git clone https://github.com/ARMmbed/mbedtls.git
+	cp /opt/hue-emulator/ssl_server2_diyhue.c /opt/hue-emulator/mbedtls
+	cd /opt/hue-emulator/mbedtls
+	git checkout master
+	git submodule update --init --recursive
+	export CC=gcc && make no_test
+	wait
+	gcc -I../mbedtls/include ssl_server2_diyhue.c -o ssl_server2_diyhue -L../mbedtls/library -lmbedtls -lmbedx509 -lmbedcrypto
+	wait
+	cp /opt/hue-emulator/mbedtls/ssl_server2_diyhue /opt/hue-emulator/entertain-srv
+	cd /opt/tmp/diyHue-master/BridgeEmulator
+	wait
+	rm -Rf /opt/hue-emulator/mbedtls
+
+else
+	
+	# Use Prebuilt Binary
+	machine_type=$(uname -m)
+	case $machine_type in
+		 aarch64)
+			  echo -e "\033[32m Copying entertainment-aarch64.\033[0m"
+			  cp entertainment-aarch64 /opt/hue-emulator/entertain-srv
+			  ;;
+		 arm*)
+			  echo -e "\033[32m Copying entertainment-arm.\033[0m"
+			  cp entertainment-arm /opt/hue-emulator/entertain-srv
+			  ;;
+		 x86_64|amd64)
+			  echo -e "\033[32m Copying entertainment-x86_64.\033[0m"
+			  cp entertainment-x86_64 /opt/hue-emulator/entertain-srv
+			  ;;
+		 i?86)
+			  echo -e "\033[32m Copying entertainment-i686.\033[0m"
+			  cp entertainment-i686 /opt/hue-emulator/entertain-srv
+			  ;;
+		 *) # Default to MIPS
+			  echo -e "\033[32m Copying entertainment-mips.\033[0m"
+			  cp entertainment-mips /opt/hue-emulator/entertain-srv
+			  ;;
+	esac
+fi
+
 rm -Rf /opt/hue-emulator/functions/network.py
 mv /opt/hue-emulator/functions/network_OpenWrt.py /opt/hue-emulator/functions/network.py
 wait
 echo -e "\033[32m Copying startup service.\033[0m"
-cp hueemulatorWrt-service /etc/init.d/
+cp /opt/tmp/diyHue-master/BridgeEmulator/hueemulatorWrt-service /etc/init.d/
 echo -e "\033[32m Changing permissions.\033[0m"
 chmod +x /etc/init.d/hueemulatorWrt-service
 chmod +x /opt/hue-emulator/HueEmulator3.py


### PR DESCRIPTION
…d add option to build entertain-srv from sources during update

This PR is to fix the bug #258 

Also optionally (As the x64 binaries were working for me), by setting the environment variable "export COMPILE_ENTERTAIN_SRV=true" the binaries will get compiled from source rather than just copied from the repo.