### PR TITLE
Fix failing dxState update

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1813,7 +1813,8 @@ class S(BaseHTTPRequestHandler):
                 elif url_pices[3] == "sensors":
                     if url_pices[5] == "state":
                         for key in put_dictionary.keys():
-                            if bridge_config["sensors"][url_pices[4]]["state"][key] != put_dictionary[key]:
+                            # track time of state changes in dxState  
+                            if not key in bridge_config["sensors"][url_pices[4]]["state"] or bridge_config["sensors"][url_pices[4]]["state"][key] != put_dictionary[key]:
                                 dxState["sensors"][url_pices[4]]["state"][key] = current_time
                     elif url_pices[4] == "1":
                         bridge_config["sensors"]["1"]["config"]["configured"] = True ##mark daylight sensor as configured


### PR DESCRIPTION
After creating setup for tradfri motion sensors in combined mode through Hue Essentials there sometimes was no "status" and "lastupdated" attribute in state. diyHue failed on updating dxState since it could not check the current status.

Adding 2nd condition if attribute state[key] is not yet available for sensor.  
```python
if not key in bridge_config["sensors"][url_pices[4]]["state"] or ... 
```


Error looked like this:
```

127.0.0.1 - - [29/Jan/2020 06:29:20] "PUT /api/1bd9b8a6145111ea992adca6323e3698/sensors/10/state HTTP/1.1" 200 -
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 34360)
Traceback (most recent call last):
  File "/usr/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/usr/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/opt/hue-emulator/HueEmulator3.py", line 1816, in do_PUT
    if bridge_config["sensors"][url_pices[4]]["state"][key] != put_dictionary[key]:
KeyError: 'status'
----------------------------------------

```