### PR TITLE
Update remoteApi

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1952,7 +1952,7 @@ if __name__ == "__main__":
         if not args.no_serve_https:
             Thread(target=run, args=[True]).start()
         Thread(target=daylightSensor).start()
-        Thread(target=remoteApi, args=[bridge_config["config"]]).start()
+        Thread(target=remoteApi, args=[HOST_IP, bridge_config["config"]]).start()
         if disableOnlineDiscover == False:
             Thread(target=remoteDiscover, args=[bridge_config["config"]]).start()
 

--- a/BridgeEmulator/functions/remoteApi.py
+++ b/BridgeEmulator/functions/remoteApi.py
@@ -5,7 +5,7 @@ import urllib.parse
 import json
 from time import sleep
 
-def remoteApi(config):
+def remoteApi(HOST_IP, config):
     url = 'https://remote.diyhue.org/devices'
     while True:
         if config["Remote API enabled"]:
@@ -15,13 +15,13 @@ def remoteApi(config):
                     if  response.text != '{renew}':
                         data = json.loads(response.text)
                         if data["method"] == 'GET':
-                            bridgeReq = requests.get('http://localhost/' + data['address'], timeout=5)
+                            bridgeReq = requests.get('http://' + HOST_IP + '/' + data['address'], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
                         if data["method"] == 'POST':
-                            bridgeReq = requests.post('http://localhost/' + data['address'], json=data["body"], timeout=5)
+                            bridgeReq = requests.post('http://' + HOST_IP + '/' + data['address'], json=data["body"], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
                         if data["method"] == 'PUT':
-                            bridgeReq = requests.put('http://localhost/' + data['address'], json=data["body"], timeout=5)
+                            bridgeReq = requests.put('http://' + HOST_IP + '/' + data['address'], json=data["body"], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
 
                 else:


### PR DESCRIPTION
#356 breaks remoteApi. Fixed with this update.

> Updated remoteApi to get it working even if you listen on a single interface.
> Just renamed `'localhost'` to `HOST_IP`, because with 'localhost' all requests are made to loopback interface, which of course is not the one we need.
> In order to do this you need to pass `HOST_IP` as argument. It's not so neat, but it works. A solution could be moving remoteApi function to HueEmulator3.py or doing a complete restyling into a class-based application.