### PR TITLE
Prevent non supported brightness value for IKEA Tradfri bulb

### DIFF
--- a/BridgeEmulator/functions/lightRequest.py
+++ b/BridgeEmulator/functions/lightRequest.py
@@ -116,6 +116,8 @@ def sendLightRequest(light, data, lights, addresses):
                 elif key == "transitiontime":
                     payload["5712"] = value
                 elif key == "bri":
+                    if value > 254:
+                        value = 254
                     payload["5851"] = value
                 elif key == "ct":
                     if value < 270:


### PR DESCRIPTION
If a brightness value 255 is sent to IKEA Tradfri bulb then the bulb does not switch on.
The maximum brightness is 254. Fix prevents malfunction in combination with Somfy TaHoma.
