### PR TITLE
Improve user experience

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -41,12 +41,13 @@ protocols = [yeelight, tasmota, native_single, native_multi, esphome]
 ap = argparse.ArgumentParser()
 
 # Arguements can also be passed as Environment Variables.
-ap.add_argument("--ip", help="The IP address of the host system", type=str)
-ap.add_argument("--http-port", help="The port to listen on for HTTP", type=int)
-ap.add_argument("--mac", help="The MAC address of the host system", type=str)
-ap.add_argument("--no-serve-https", action='store_true', help="Don't listen on port 443 with SSL")
 ap.add_argument("--debug", action='store_true', help="Enables debug output")
+ap.add_argument("--bind-ip", help="The IP address to listen on", type=str)
 ap.add_argument("--docker", action='store_true', help="Enables setup for use in docker container")
+ap.add_argument("--ip", help="The IP address of the host system (Docker)", type=str)
+ap.add_argument("--http-port", help="The port to listen on for HTTP (Docker)", type=int)
+ap.add_argument("--mac", help="The MAC address of the host system (Docker)", type=str)
+ap.add_argument("--no-serve-https", action='store_true', help="Don't listen on port 443 with SSL")
 ap.add_argument("--ip-range", help="Set IP range for light discovery. Format: <START_IP>,<STOP_IP>", type=str)
 ap.add_argument("--scan-on-host-ip", action='store_true', help="Scan the local IP address when discovering new lights")
 ap.add_argument("--deconz", help="Provide the IP address of your Deconz host. 127.0.0.1 by default.", type=str)
@@ -63,11 +64,20 @@ if args.debug or (os.getenv('DEBUG') and (os.getenv('DEBUG') == "true" or os.get
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
     root.addHandler(ch)
+    
+if args.bind_ip:
+    BIND_IP = args.bind_ip
+elif os.getenv('BIND_IP'):
+    BIND_IP = os.getenv('BIND_IP')
+else:
+    BIND_IP = ''
 
 if args.ip:
     HOST_IP = args.ip
 elif os.getenv('IP'):
     HOST_IP = os.getenv('IP')
+elif BIND_IP:
+    HOST_IP = BIND_IP
 else:
     HOST_IP = getIpAddress()
 
@@ -1912,7 +1922,7 @@ class ThreadingSimpleServer(ThreadingMixIn, HTTPServer):
 
 def run(https, server_class=ThreadingSimpleServer, handler_class=S):
     if https:
-        server_address = ('', HOST_HTTPS_PORT)
+        server_address = (BIND_IP, HOST_HTTPS_PORT)
         httpd = server_class(server_address, handler_class)
         ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ctx.load_cert_chain(certfile="/opt/hue-emulator/cert.pem")
@@ -1925,7 +1935,7 @@ def run(https, server_class=ThreadingSimpleServer, handler_class=S):
         httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
         logging.info('Starting ssl httpd...')
     else:
-        server_address = ('', HOST_HTTP_PORT)
+        server_address = (BIND_IP, HOST_HTTP_PORT)
         httpd = server_class(server_address, handler_class)
         logging.info('Starting httpd...')
     httpd.serve_forever()
@@ -1952,7 +1962,7 @@ if __name__ == "__main__":
         if not args.no_serve_https:
             Thread(target=run, args=[True]).start()
         Thread(target=daylightSensor).start()
-        Thread(target=remoteApi, args=[bridge_config["config"]]).start()
+        Thread(target=remoteApi, args=[BIND_IP, bridge_config["config"]]).start()
         if disableOnlineDiscover == False:
             Thread(target=remoteDiscover, args=[bridge_config["config"]]).start()
 

--- a/BridgeEmulator/functions/remoteApi.py
+++ b/BridgeEmulator/functions/remoteApi.py
@@ -9,7 +9,7 @@ def remoteApi(BIND_IP, config):
     if BIND_IP == '':
         ip = "localhost"
     else:
-        ip = BIND_IP:
+        ip = BIND_IP
     url = 'https://remote.diyhue.org/devices'
     while True:
         if config["Remote API enabled"]:

--- a/BridgeEmulator/functions/remoteApi.py
+++ b/BridgeEmulator/functions/remoteApi.py
@@ -5,7 +5,11 @@ import urllib.parse
 import json
 from time import sleep
 
-def remoteApi(config):
+def remoteApi(BIND_IP, config):
+    if BIND_IP == '':
+        ip = "localhost"
+    else:
+        ip = BIND_IP:
     url = 'https://remote.diyhue.org/devices'
     while True:
         if config["Remote API enabled"]:
@@ -15,13 +19,13 @@ def remoteApi(config):
                     if  response.text != '{renew}':
                         data = json.loads(response.text)
                         if data["method"] == 'GET':
-                            bridgeReq = requests.get('http://localhost/' + data['address'], timeout=5)
+                            bridgeReq = requests.get(f'http://{ip}/' + data['address'], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
                         if data["method"] == 'POST':
-                            bridgeReq = requests.post('http://localhost/' + data['address'], json=data["body"], timeout=5)
+                            bridgeReq = requests.post(f'http://{ip}/' + data['address'], json=data["body"], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
                         if data["method"] == 'PUT':
-                            bridgeReq = requests.put('http://localhost/' + data['address'], json=data["body"], timeout=5)
+                            bridgeReq = requests.put(f'http://{ip}/' + data['address'], json=data["body"], timeout=5)
                             requests.post(url + '?apikey=' + base64.urlsafe_b64encode(bytes(config["Hue Essentials key"], "utf8")).decode("utf-8"), timeout=5, json=json.loads(bridgeReq.text))
 
                 else:

--- a/BridgeEmulator/hueemulatorWrt-service
+++ b/BridgeEmulator/hueemulatorWrt-service
@@ -2,12 +2,34 @@
 
 SCRIPT_NAME="HueEmulator3.py"
 SCRIPT_PATH="/opt/hue-emulator"
+SCRIPT_PARAMS=""
+PID_FILE="/tmp/hue-emulator.pid"
 
 START=98
 
 start() {
-sleep 5
-. /etc/profile
-echo "Starting $SCRIPT_NAME"
-nohup python3 $SCRIPT_PATH/$SCRIPT_NAME >/dev/null 2>&1 &
+  if [ -f "$PID_FILE" ] && kill -0 $(cat "$PID_FILE"); then
+    echo "$SCRIPT_NAME already running"
+    return 1
+  fi
+  sleep 5
+  . /etc/profile > /dev/null
+  nohup python3 $SCRIPT_PATH/$SCRIPT_NAME $SCRIPT_PARAMS >/dev/null 2>&1 &
+  echo $! > $PID_FILE
+  echo "Started $SCRIPT_NAME."
+}
+
+stop() {
+  if [ ! -f "$PID_FILE" ] && ! kill -0 $(cat "$PID_FILE"); then
+    echo "$SCRIPT_NAME not running"
+    return 1
+  fi
+  kill -2 $(cat $PID_FILE)
+  rm -f "$PID_FILE"
+  echo "Stopped $SCRIPT_NAME."
+}
+
+restart() {
+  stop
+  start
 }


### PR DESCRIPTION
### hueemulatorWrt-service:
Added stop() and restart() and improved start() using PID file.
### HueEmulator3.py:
Added --bind-ip parameter that defines the IP address for diyHue to listen on.
Useful for OpenWrt, where you may want to keep uhttpd or nginx listening on ports 80 and 443, and make diyHue act on another interface or another IP address.
### remoteApi.py
Updated remoteApi to get it working even if you listen on a single interface.
Just renamed 'localhost' to BIND_IP because with 'localhost' all requests are made to loopback interface, which of course is not the one we need.
In order to do this you need to pass BIND_IP as argument. It's not so neat, but it works. A solution could be moving remoteApi function to HueEmulator3.py or doing a complete restyling into a class-based application.