### PR TITLE
Entertainment mode: fix hue bridge lights brightness

### DIFF
--- a/BridgeEmulator/functions/entertainment.py
+++ b/BridgeEmulator/functions/entertainment.py
@@ -55,6 +55,8 @@ def entertainmentService(lights, addresses, groups, host_ip):
                                             if lightStatus[lightId]["on"] == False: #Turn on if color is not black
                                                 sendLightRequest(str(lightId), {"on": True, "transitiontime": 3}, lights, addresses, None, host_ip)
                                                 lightStatus[lightId]["on"] = True
+                                            elif proto == "hue":
+                                                sendLightRequest(str(lightId), {"xy": convert_rgb_xy(r, g, b), "transitiontime": 3, "bri": int((r + b + g) / 3)}, lights, addresses, [r, g, b], host_ip)
                                             elif brABS > 50: # to optimize, send brightness only if difference is bigger than this value
                                                 sendLightRequest(str(lightId), {"bri": int((r + b + g) / 3), "transitiontime": 150 / brABS}, lights, addresses, None, host_ip)
                                                 lightStatus[lightId]["bri"] = int((r + b + g) / 3)


### PR DESCRIPTION
I noticed that the brightness is not updated for Hue Bridge Lights in Entertainment mode. 

The Hue API allows to update the color and brightness at the same time. This fix makes use of this.

I also noticed that we are currently using only every 24th frame and the rest gets dropped. Are there any ideas to forward the full entertainment stream to the Hue Bridge? Are there known rate limits on the Hue Bridge API?