### PR TITLE
Add hascolor parameter to domoticz lights to allow for just plain dim…

### DIFF
--- a/BridgeEmulator/functions/lightRequest.py
+++ b/BridgeEmulator/functions/lightRequest.py
@@ -50,37 +50,42 @@ def sendLightRequest(light, data, lights, addresses, rgb = None, entertainmentHo
                         else:
                             url += "&switchcmd=Off"
             else:
-                url += "&param=setcolbrightnessvalue"
-                color_data = {}
-
-                old_light_state = lights[light]["state"]
-                colormode = old_light_state["colormode"]
-                ct = old_light_state["ct"]
-                bri = old_light_state["bri"]
-                xy = old_light_state["xy"]
-
                 if "bri" in data:
                     bri = data["bri"]
-                if "ct" in data:
-                    ct = data["ct"]
-                if "xy" in data:
-                    xy = data["xy"]
                 bri = int(bri)
+                if lights[light]["hascolor"]:
+                    url += "&param=setcolbrightnessvalue"
+                    color_data = {}
 
-                color_data["m"] = 1 #0: invalid, 1: white, 2: color temp, 3: rgb, 4: custom
-                if colormode == "ct":
-                    color_data["m"] = 2
-                    ct01 = (ct - 153) / (500 - 153) #map color temperature from 153-500 to 0-1
-                    ct255 = ct01 * 255 #map color temperature from 0-1 to 0-255
-                    color_data["t"] = ct255
-                elif colormode == "xy":
-                    color_data["m"] = 3
-                    if rgb:
-                        (color_data["r"], color_data["g"], color_data["b"]) = rgbBrightness(rgb, bri)
-                    else:
-                        (color_data["r"], color_data["g"], color_data["b"]) = convert_xy(xy[0], xy[1], bri)
-                url += "&color="+json.dumps(color_data)
-                url += "&brightness=" + str(round(float(bri)/255*100))
+                    old_light_state = lights[light]["state"]
+                    colormode = old_light_state["colormode"]
+                    bri = old_light_state["bri"]
+                    if colormode == "ct":
+                        ct = old_light_state["ct"]
+                    if colormode == "xy":
+                        xy = old_light_state["xy"]
+
+                    if "ct" in data:
+                        ct = data["ct"]
+                    if "xy" in data:
+                        xy = data["xy"]
+
+                    color_data["m"] = 1 #0: invalid, 1: white, 2: color temp, 3: rgb, 4: custom
+                    if colormode == "ct":
+                        color_data["m"] = 2
+                        ct01 = (ct - 153) / (500 - 153) #map color temperature from 153-500 to 0-1
+                        ct255 = ct01 * 255 #map color temperature from 0-1 to 0-255
+                        color_data["t"] = ct255
+                    elif colormode == "xy":
+                        color_data["m"] = 3
+                        if rgb:
+                            (color_data["r"], color_data["g"], color_data["b"]) = rgbBrightness(rgb, bri)
+                        else:
+                            (color_data["r"], color_data["g"], color_data["b"]) = convert_xy(xy[0], xy[1], bri)
+                    url += "&color="+json.dumps(color_data)
+                    url += "&brightness=" + str(round(float(bri)/255*100))
+                else:
+                    url += "&param=switchlight&switchcmd=Set%20Level&level=" + str(bri)
 
             urlObj = {}
             urlObj["url"] = url

--- a/BridgeEmulator/functions/ssdp.py
+++ b/BridgeEmulator/functions/ssdp.py
@@ -32,7 +32,7 @@ def ssdpSearch(ip, port, mac):
                 logging.debug("Sending M-Search response to " + address[0])
                 for x in range(3):
                    sock.sendto(bytes(Response_message + "ST: " + custom_response_message[x]["st"] + "\r\nUSN: " + custom_response_message[x]["usn"] + "\r\n\r\n", "utf8"), address)
-        sleep(1)
+        sleep(0.5)
 
 def ssdpBroadcast(ip, port, mac):
     logging.debug("start ssdp broadcast")


### PR DESCRIPTION
This refactors the code in lightRequest.py to look for a hascolor config option.

If the option is available then just use a simple "Set Level" command to domoticz otherwise continue as before.