### PR TITLE
sysvinit service added for old systems

### DIFF
--- a/BridgeEmulator/easy_install.sh
+++ b/BridgeEmulator/easy_install.sh
@@ -152,12 +152,21 @@ esac
 chmod +x /opt/hue-emulator/entertain-srv
 chmod +x /opt/hue-emulator/coap-client-linux
 chmod +x /opt/hue-emulator/check_updates.sh
-cp hue-emulator.service /lib/systemd/system/
+
+if [ -d "/run/systemd/system/" ]; then
+    cp hue-emulator.service /lib/systemd/system/
+    chmod 644 /lib/systemd/system/hue-emulator.service
+    systemctl daemon-reload
+    systemctl enable hue-emulator.service
+    systemctl start hue-emulator.service
+else
+    cp hue-emulator.sysvinit /etc/init.d/hue-emulator
+    chmod 644 /etc/init.d/hue-emulator
+    update-rc.d hue-emulator defaults
+    service hue-emulator start
+fi
+
 cd ../../
 rm -rf diyHue.zip diyHue-master
-chmod 644 /lib/systemd/system/hue-emulator.service
-systemctl daemon-reload
-systemctl enable hue-emulator.service
-systemctl start hue-emulator.service
 
 echo -e "\033[32m Installation completed. Open Hue app and search for bridges.\033[0m"

--- a/BridgeEmulator/easy_install.sh
+++ b/BridgeEmulator/easy_install.sh
@@ -57,8 +57,13 @@ cd diyHue-master/BridgeEmulator/
 if [ -d "/opt/hue-emulator" ]; then
         if [ -f "/opt/hue-emulator/public.crt" ]; then
 		echo -e "\033[31m WARNING!! Nginx is not necessary anymore, it will be stopped.\033[0m"
-        	systemctl stop nginx
-		systemctl disable nginx
+    if [ -d "/run/systemd/system/" ]; then
+        systemctl stop nginx
+        systemctl disable nginx
+    else
+        service nginx stop
+        update-rc.d nginx disable
+    fi
 		cp /opt/hue-emulator/private.key /tmp/cert.pem
                 cat /opt/hue-emulator/public.crt >> /tmp/cert.pem
 	elif [ -f "/opt/hue-emulator/cert.pem" ]; then
@@ -84,7 +89,12 @@ if [ -d "/opt/hue-emulator" ]; then
 		fi
         fi
 
-	systemctl stop hue-emulator.service
+        if [ -d "/run/systemd/system/" ]; then
+          systemctl stop hue-emulator.service
+        else
+            service hue-emulator stop
+            update-rc.d nginx disable
+        fi
         echo -e "\033[33m Existing installation found, performing upgrade.\033[0m"
         cp /opt/hue-emulator/config.json /tmp
         rm -rf /opt/hue-emulator

--- a/BridgeEmulator/easy_uninstall.sh
+++ b/BridgeEmulator/easy_uninstall.sh
@@ -2,7 +2,11 @@
 cd /tmp
 
 echo -e "\033[36m Stopping diyHue.\033[0m"
-systemctl stop hue-emulator.service
+if [ -d "/run/systemd/system/" ]; then
+    systemctl stop hue-emulator.service
+else
+    service hue-emulator stop
+fi
 
 ### Uninstalling astral library for sunrise/sunset routines
 echo -e "\033[36m Uninstalling Python Astral.\033[0m"
@@ -20,9 +24,14 @@ echo -e "\033[36m Uninstalling Hue Emulator.\033[0m"
 
 rm -rf /opt/hue-emulator/
 
-systemctl disable hue-emulator.service
-rm /lib/systemd/system/hue-emulator.service
-systemctl daemon-reload
+if [ -d "/run/systemd/system/" ]; then
+    systemctl disable hue-emulator.service
+    rm /lib/systemd/system/hue-emulator.service
+    systemctl daemon-reload
+else
+    update-rc.d hue-emulator disable
+    rm /etc/init.d/hue-emulator
+fi
 
 ### Uninstalling dependencies
 echo -e "\033[36m Upon setup, diyHue installs some packages.\033[0m"

--- a/BridgeEmulator/hue-emulator.sysvinit
+++ b/BridgeEmulator/hue-emulator.sysvinit
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+start() {
+  if [ -z "$(ps aux | grep HueEmulator3.py | grep -v grep)" ]; then
+    echo "Starting Hue server..."
+    python3 /opt/hue-emulator/HueEmulator3.py &>>/opt/hue-emulator/log.txt &
+    echo "Hue server has been started!"
+    echo
+  else
+    echo "Already running!"
+  fi
+}
+
+status() {
+  if [ -z "$(ps aux | grep HueEmulator3.py | grep -v grep)" ]; then
+    echo "Not running"
+  else
+    echo "Running"
+  fi
+}
+
+stop() {
+  if [ -z "$(ps aux | grep HueEmulator3.py | grep -v grep)" ]; then
+    echo "It's not running!"
+  else
+    echo "Stopping Hue server..."
+    curl http://127.0.0.1/save
+    /bin/sleep 1
+    pkill -f "/opt/hue-emulator/HueEmulator3.py"
+    echo
+    echo
+    echo "Hue server has been stopped!"
+  fi
+}
+
+### main logic ###
+case "$1" in
+start)
+  start
+  ;;
+stop)
+  stop
+  ;;
+status)
+  status
+  ;;
+restart | reload | condrestart)
+  stop
+  start
+  ;;
+*)
+  echo $"Usage: $0 {start|stop|restart|reload|status}"
+  exit 1
+  ;;
+esac
+
+exit 0


### PR DESCRIPTION
easy_install script assumes the system is running `systemd` which is true unless you're running a very old distribution (Ubuntu 14.04) on a board that's not maintained anymore (I got [Radxa Rock Pro](https://wiki.radxa.com/Rock)).

Still it's possible to [install python3 on those systems](https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get) and run diyHue, and this is the only missing piece of that puzzle - a service file. It [detects if systemd or sysvinit is running](https://www.freedesktop.org/software/systemd/man/sd_booted.html) and uses the corresponding service file

PS. I haven't found a contribution guide or anything like that, so sorry in advance if that's not how things are done around here :)  