### PR TITLE
Astral fix

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,97 +1,80 @@
-name: Build Docker Image
+name: Docker build and push
 
 on:
   push:
+    branches:
+      - master
+      - beta
+      - develop
 
 jobs:
-  build:
+  Publish-to-docker:
     runs-on: ubuntu-latest
-    name: Build and Publish
     steps:
-      - name: Set Docker Repository
+      - name: Set env vars
         run: |
-          if [ ${GITHUB_REPOSITORY} == "diyhue/diyHue" ]; then
-            export REPO_NAME="diyhue/core"
-          else
-            export REPO_NAME=$GITHUB_REPOSITORY
-          fi
-          echo Repository set as: $REPO_NAME
-          echo "::set-env name=DOCKER_REPO::$REPO_NAME"
-
-      - name: Checkout
+          export DOCKER_TAG=$([[ $GITHUB_REF == *"master"* ]] && echo "latest" || echo $GITHUB_REF)
+          echo Will tag image as: $DOCKER_TAG
+          echo "::set-env name=DOCKER_TAG::$DOCKER_TAG"
+      -
+        name: Checkout
         uses: actions/checkout@v1
-
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
-
-      - name: List available platforms
+        with:
+          version: latest
+      -
+        name: List available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-
-      - name: Docker login (needs DOCKER_USERNAME and DOCKER_PASSWORD secrets)
+      -
+        name: Docker login (needs DOCKER_USERNAME and DOCKER_PASSWORD secrets)
         run:
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build Image
+      -
+        name: Publish to docker as diyHue/core
+        if:  ${{ success() && startsWith(github.repository, 'diyhue/')}}
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            -o "type=image,push=false" \
+            --push \
             -f ./.build/Dockerfile \
-            -t diyhue/core:CI \
+            -t diyhue/core:$DOCKER_TAG \
+            -t diyhue/core:master-$GITHUB_SHA \
+            .
+      -
+        name: Publish to docker as github_user/github_repo
+        if: ${{ success() && !startsWith(github.repository, 'diyhue/')}}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 \
+            --push \
+            -f ./.build/Dockerfile \
+            -t $GITHUB_REPOSITORY:$DOCKER_TAG \
+            -t $GITHUB_REPOSITORY:master-$GITHUB_SHA \
             .
 
-      - name: Deploy Commit ID
-        if: ${{ github.head_ref == '' && github.sha != '' }}
-        run: |
-          docker tag diyhue/core:CI $DOCKER_REPO:$GITHUB_SHA
-          docker push $DOCKER_REPO:$GITHUB_SHA
-          echo $DOCKER_REPO:$GITHUB_SHA published
-
-      - name: Deploy Run Number
-        if: ${{ github.head_ref == '' && github.sha != '' }}
-        run: |
-          docker tag diyhue/core:CI $DOCKER_REPO:$GITHUB_RUN_NUMBER
-          docker push $DOCKER_REPO:$GITHUB_RUN_NUMBER
-          echo $DOCKER_REPO:$GITHUB_RUN_NUMBER published
-
-      - name: Deploy Latest
-        if: ${{ github.head_ref == '' && github.ref == 'refs/heads/master' }}
-        run: |
-          docker tag diyhue/core:CI $DOCKER_REPO:latest
-          docker push $DOCKER_REPO:latest
-          echo $DOCKER_REPO:latest published
-
-      - name: Deploy Branch
-        if: ${{ github.head_ref == '' && startsWith(github.ref, 'refs/heads/') }}
-        run: |
-          docker tag diyhue/core:CI $DOCKER_REPO:${GITHUB_REF##*/}
-          docker push $DOCKER_REPO:${GITHUB_REF##*/}
-          echo $DOCKER_REPO:${GITHUB_REF##*/} published
-
-      - name: Deploy Tag
-        if: ${{ github.head_ref == '' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          docker tag diyhue/core:CI $DOCKER_REPO:${GITHUB_REF##*/}
-          docker push $DOCKER_REPO:${GITHUB_REF##*/}
-          echo $DOCKER_REPO:${GITHUB_REF##*/} published
-
-  Test:
+  Run-tests:
     runs-on: ubuntu-latest
-    name: Test Image
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v1
-      - name: Build docker image
+      -
+        name: Build docker image
         run: |
           docker build -t diyhue/core:ci -f ./.build/Dockerfile --build-arg TARGETPLATFORM=linux/amd64 .
-      - name: Run docker image
+      -
+        name: Run docker image
         if: success()
         run: |
           docker run -d --name "diyhue" --network="host" -v '/mnt/hue-emulator/export/':'/opt/hue-emulator/export/':'rw' -e 'MAC=b8:27:eb:d4:dc:11' -e 'IP=192.168.1.123' -e 'DECONZ=192.168.1.111' -e 'IP_RANGE=5,6' -e 'DEBUG=true' diyhue/core:ci
           sleep 15
           docker logs diyhue
-      - name: Cleanup
+      -
+        name: Cleanup
         run: |
           docker kill diyhue
           docker rm diyhue
+

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,80 +1,97 @@
-name: Docker build and push
+name: Build Docker Image
 
 on:
   push:
-    branches:
-      - master
-      - beta
-      - develop
 
 jobs:
-  Publish-to-docker:
+  build:
     runs-on: ubuntu-latest
+    name: Build and Publish
     steps:
-      - name: Set env vars
+      - name: Set Docker Repository
         run: |
-          export DOCKER_TAG=$([[ $GITHUB_REF == *"master"* ]] && echo "latest" || echo $GITHUB_REF)
-          echo Will tag image as: $DOCKER_TAG
-          echo "::set-env name=DOCKER_TAG::$DOCKER_TAG"
-      -
-        name: Checkout
+          if [ ${GITHUB_REPOSITORY} == "diyhue/diyHue" ]; then
+            export REPO_NAME="diyhue/core"
+          else
+            export REPO_NAME=$GITHUB_REPOSITORY
+          fi
+          echo Repository set as: $REPO_NAME
+          echo "::set-env name=DOCKER_REPO::$REPO_NAME"
+
+      - name: Checkout
         uses: actions/checkout@v1
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
-        with:
-          version: latest
-      -
-        name: List available platforms
+
+      - name: List available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-      -
-        name: Docker login (needs DOCKER_USERNAME and DOCKER_PASSWORD secrets)
+
+      - name: Docker login (needs DOCKER_USERNAME and DOCKER_PASSWORD secrets)
         run:
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Publish to docker as diyHue/core
-        if:  ${{ success() && startsWith(github.repository, 'diyhue/')}}
+
+      - name: Build Image
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            --push \
+            -o "type=image,push=false" \
             -f ./.build/Dockerfile \
-            -t diyhue/core:$DOCKER_TAG \
-            -t diyhue/core:master-$GITHUB_SHA \
-            .
-      -
-        name: Publish to docker as github_user/github_repo
-        if: ${{ success() && !startsWith(github.repository, 'diyhue/')}}
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            --push \
-            -f ./.build/Dockerfile \
-            -t $GITHUB_REPOSITORY:$DOCKER_TAG \
-            -t $GITHUB_REPOSITORY:master-$GITHUB_SHA \
+            -t diyhue/core:CI \
             .
 
-  Run-tests:
+      - name: Deploy Commit ID
+        if: ${{ github.head_ref == '' && github.sha != '' }}
+        run: |
+          docker tag diyhue/core:CI $DOCKER_REPO:$GITHUB_SHA
+          docker push $DOCKER_REPO:$GITHUB_SHA
+          echo $DOCKER_REPO:$GITHUB_SHA published
+
+      - name: Deploy Run Number
+        if: ${{ github.head_ref == '' && github.sha != '' }}
+        run: |
+          docker tag diyhue/core:CI $DOCKER_REPO:$GITHUB_RUN_NUMBER
+          docker push $DOCKER_REPO:$GITHUB_RUN_NUMBER
+          echo $DOCKER_REPO:$GITHUB_RUN_NUMBER published
+
+      - name: Deploy Latest
+        if: ${{ github.head_ref == '' && github.ref == 'refs/heads/master' }}
+        run: |
+          docker tag diyhue/core:CI $DOCKER_REPO:latest
+          docker push $DOCKER_REPO:latest
+          echo $DOCKER_REPO:latest published
+
+      - name: Deploy Branch
+        if: ${{ github.head_ref == '' && startsWith(github.ref, 'refs/heads/') }}
+        run: |
+          docker tag diyhue/core:CI $DOCKER_REPO:${GITHUB_REF##*/}
+          docker push $DOCKER_REPO:${GITHUB_REF##*/}
+          echo $DOCKER_REPO:${GITHUB_REF##*/} published
+
+      - name: Deploy Tag
+        if: ${{ github.head_ref == '' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          docker tag diyhue/core:CI $DOCKER_REPO:${GITHUB_REF##*/}
+          docker push $DOCKER_REPO:${GITHUB_REF##*/}
+          echo $DOCKER_REPO:${GITHUB_REF##*/} published
+
+  Test:
     runs-on: ubuntu-latest
+    name: Test Image
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v1
-      -
-        name: Build docker image
+      - name: Build docker image
         run: |
           docker build -t diyhue/core:ci -f ./.build/Dockerfile --build-arg TARGETPLATFORM=linux/amd64 .
-      -
-        name: Run docker image
+      - name: Run docker image
         if: success()
         run: |
           docker run -d --name "diyhue" --network="host" -v '/mnt/hue-emulator/export/':'/opt/hue-emulator/export/':'rw' -e 'MAC=b8:27:eb:d4:dc:11' -e 'IP=192.168.1.123' -e 'DECONZ=192.168.1.111' -e 'IP_RANGE=5,6' -e 'DEBUG=true' diyhue/core:ci
           sleep 15
           docker logs diyhue
-      -
-        name: Cleanup
+      - name: Cleanup
         run: |
           docker kill diyhue
           docker rm diyhue
-

--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1189,7 +1189,6 @@ def daylightSensor():
     if bridge_config["sensors"]["1"]["modelid"] != "PHDL00" or not bridge_config["sensors"]["1"]["config"]["configured"]:
         return
 
-    import pytz
     from astral.sun import sun
     from astral import LocationInfo
     localzone = LocationInfo('localzone', bridge_config["config"]["timezone"].split("/")[1], bridge_config["config"]["timezone"], float(bridge_config["sensors"]["1"]["config"]["lat"][:-1]), float(bridge_config["sensors"]["1"]["config"]["long"][:-1]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astral==1.6.1
+astral==2.2
 ws4py==0.5.1
 requests==2.20.0
 paho-mqtt==1.5.0


### PR DESCRIPTION
I was looking into why #428 is happening and noticed a mismatch between astral module version used in requirements.txt (1.6.1) and the one used in easy_install script (2.2).  Deps from requirements.txt are installed to docker.
Now, I know that the source of truth should be the docker method, yet the code seems to had been written against v2.2 of the library. None of the lines below will work in 1.6.1, and are completely valid in 2.2:
```python
from astral.sun import sun
from astral import LocationInfo
```
Also, no need to import pytz as is happens inside astral module (__ init __.py, line 54):
```python
try:
    import pytz
except ImportError:
    raise ImportError(("The astral module requires the pytz module to be available."))
```
This solution has been tested according to https://diyhue.readthedocs.io/en/latest/development.html#docker-development 