### PR TITLE
Fix various small KeyErrors

### DIFF
--- a/BridgeEmulator/webServer/server.py
+++ b/BridgeEmulator/webServer/server.py
@@ -248,7 +248,8 @@ def splitLightsToDevices(group, state, scene={}):
         # if "transitiontime" in lightsData[light]:
         #     del lightsData[light]["transitiontime"]
         bridge_config["lights"][light]["state"].update(lightsData[light])
-    updateGroupStats(list(lightsData.keys())[0], bridge_config["lights"], bridge_config["groups"])
+    if lightsData:
+        updateGroupStats(list(lightsData.keys())[0], bridge_config["lights"], bridge_config["groups"])
 
 
 def groupZero(state):
@@ -730,7 +731,10 @@ class S(BaseHTTPRequestHandler):
                                 scenelist["scenes"][scene]["lights"] = bridge_config["groups"][bridge_config["scenes"][scene]["group"]]["lights"]
                         self._set_end_headers(bytes(json.dumps(scenelist["scenes"][url_pices[4]],separators=(',', ':'),ensure_ascii=False), "utf8"))
                     else:
-                        self._set_end_headers(bytes(json.dumps(bridge_config[url_pices[3]][url_pices[4]],separators=(',', ':'),ensure_ascii=False), "utf8"))
+                        if url_pices[4] in bridge_config[url_pices[3]]:
+                            self._set_end_headers(bytes(json.dumps(bridge_config[url_pices[3]][url_pices[4]], separators=(',', ':'), ensure_ascii=False), "utf8"))
+                        else:
+                            self._set_end_headers(bytes())
             elif (len(url_pices) == 4 and url_pices[3] == "config") or (len(url_pices) == 3 and url_pices[2] == "config"): #used by applications to discover the bridge
                 self._set_end_headers(bytes(json.dumps({"name": bridge_config["config"]["name"],"datastoreversion": 70, "swversion": bridge_config["config"]["swversion"], "apiversion": bridge_config["config"]["apiversion"], "mac": bridge_config["config"]["mac"], "bridgeid": bridge_config["config"]["bridgeid"], "factorynew": False, "replacesbridgeid": None, "modelid": bridge_config["config"]["modelid"],"starterkitid":""},separators=(',', ':'),ensure_ascii=False), "utf8"))
             else: #user is not in whitelist


### PR DESCRIPTION
Fixes two small bugs:
a) on a fresh setup with one bridge and 3 lights, the Hue app requests the data for a non-existing sensor (/api/sensors/2 and /api/sensors/3, although only one sensor exists at that point: a daylight sensor):
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib/python3.7/http/server.py", line 428, in handle
    self.handle_one_request()
  File "/usr/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/opt/hue-emulator/webServer/server.py", line 733, in do_GET
    self._set_end_headers(bytes(json.dumps(bridge_config[url_pices[3]][url_pices[4]],separators=(',', ':'),ensure_ascii=False), "utf8"))
KeyError: '3'
```
As a fix, this returns an empty response when the server is requested about non-existing data.

b) When there's no lights added yet, clicking "Turn all on" button in Web UI results in this exception:
```
2020-08-23 20:03:16,399 - functions.lightRequest - INFO - sync with lights
2020-08-23 20:03:20,261 - webServer.server - INFO - in PUT method
2020-08-23 20:03:20,264 - webServer.server - INFO - /api/web-ui-50417/groups/0/action
2020-08-23 20:03:20,270 - webServer.server - INFO - b'{"on":true}'
Exception in thread Thread-16:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/hue-emulator/webServer/server.py", line 251, in splitLightsToDevices
    updateGroupStats(list(lightsData.keys())[0], bridge_config["lights"], bridge_config["groups"])
IndexError: list index out of range
```
As a fix, we're checking if there are any groups at all, before updating their state.