### PR TITLE
Fix/Import missing color convertor lightrequests

### DIFF
--- a/BridgeEmulator/functions/lightRequest.py
+++ b/BridgeEmulator/functions/lightRequest.py
@@ -1,6 +1,6 @@
 import logging, json
 from functions.request import sendRequest
-from functions.colors import convert_rgb_xy, convert_xy, rgbBrightness 
+from functions.colors import convert_rgb_xy, convert_xy, rgbBrightness, hsv_to_rgb
 from subprocess import check_output
 from protocols import protocols
 from datetime import datetime, timedelta


### PR DESCRIPTION
`hsv_to_rgb` from the colors functions was not imported in `lightrequests.py` even though it was needed sometimes.

Mitigates this error I encountered while using [this kodi addon](https://github.com/mpolednik/script.kodi.hue.ambilight) in combination with this project and some Ikea Tradfri lights.
```
  File "./HueEmulator3.py", line 1828, in do_PUT
    sendLightRequest(url_pices[4], put_dictionary, bridge_config["lights"], bridge_config["lights_address"])
  File "/opt/hue-emulator/functions/lightRequest.py", line 161, in sendLightRequest
    rgbValue = hsv_to_rgb(hue, sat, bri)
NameError: name 'hsv_to_rgb' is not defined
```
Request was 
```
2020-09-27 10:58:47,528 - root - INFO - b'{"transitiontime": 40, "on": true, "sat": 196, "hue": 25813}'
----------------------------------------
Exception happened during processing of request from ('192.168.178.70', 53250)
```