### PR TITLE
Impove Milight UDP Prot and Entertaiment function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Sensors/*
 # Ignore userdata
 BridgeEmulator/export/
 BridgeEmulator/cert.pem
+BridgeEmulator/.vscode/launch.json

--- a/BridgeEmulator/functions/entertainment.py
+++ b/BridgeEmulator/functions/entertainment.py
@@ -1,13 +1,35 @@
-import socket, logging
+import socket, logging, json
 from subprocess import Popen
 from functions.colors import convert_rgb_xy, convert_xy
 from functions.lightRequest import sendLightRequest
+from threading import Thread
+
+
+cieTolerance = 0.03 # new frames will be ignored if the color  change is smaller than this values
+briTolerange = 16 # new frames will be ignored if the brightness change is smaller than this values
+lastAppliedFrame = {}
+
+def skipSimilarFrames(light, color, brightness):
+    if light not in lastAppliedFrame: # check if light exist in dictionary
+        lastAppliedFrame[light] = {"xy": [0,0], "bri": 0}
+
+    if lastAppliedFrame[light]["xy"][0] + cieTolerance < color[0] or color[0] < lastAppliedFrame[light]["xy"][0] - cieTolerance:
+        lastAppliedFrame[light]["xy"] = color
+        return 2
+    if lastAppliedFrame[light]["xy"][1] + cieTolerance < color[1] or color[1] < lastAppliedFrame[light]["xy"][1] - cieTolerance:
+        lastAppliedFrame[light]["xy"] = color
+        return 2
+    if lastAppliedFrame[light]["bri"] + briTolerange < brightness or brightness < lastAppliedFrame[light]["bri"] - briTolerange:
+        lastAppliedFrame[light]["bri"] = brightness
+        return 1
+    return 0
+
 
 def entertainmentService(lights, addresses, groups, host_ip):
     serverSocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     serverSocket.settimeout(3) #Set a packet timeout that we catch later
     serverSocket.bind(('127.0.0.1', 2101))
-    frameID = 0
+    fremeID = 1
     lightStatus = {}
     syncing = False #Flag to check whether or not we had been syncing when a timeout occurs
     while True:
@@ -42,29 +64,43 @@ def entertainmentService(lights, addresses, groups, host_ip):
                                         esphomeLights[addresses[str(lightId)]["ip"]] = {}
                                     bri = int(max(r,g,b))
                                     esphomeLights[addresses[str(lightId)]["ip"]]["color"] = [r, g, b, bri]
+                                elif proto == "yeelight":
+                                    operation = skipSimilarFrames(lightId, lights[str(lightId)]["state"]["xy"], lights[str(lightId)]["state"]["bri"])
+                                    if operation == 1:
+                                        sendLightRequest(str(lightId), {"bri": lights[str(lightId)]["state"]["bri"], "transitiontime": 150 / lights[str(lightId)]["state"]["bri"]}, lights, addresses, None, host_ip)
+                                    elif operation == 2:
+                                        sendLightRequest(str(lightId), {"xy": lights[str(lightId)]["state"]["xy"], "transitiontime": 3}, lights, addresses, [r, g, b], host_ip)
+                                elif proto == "mi_box":
+                                    if r == 0 and  g == 0 and  b == 0:
+                                        if lightStatus[lightId]["on"]:
+                                            sendLightRequest(str(lightId), {"bri": 0, "transitiontime": 3}, lights, addresses, None, host_ip)
+                                            lightStatus[lightId]["on"] = False
+                                    elif lightStatus[lightId]["on"] == False:
+                                        sendLightRequest(str(lightId), {"bri": 255, "transitiontime": 3}, lights, addresses, None, host_ip)
+                                        lightStatus[lightId]["on"] = True
+                                    operation = skipSimilarFrames(lightId, lights[str(lightId)]["state"]["xy"], lights[str(lightId)]["state"]["bri"])
+                                    if operation == 1:
+                                        Thread(target=sendLightRequest, args=(str(lightId), {"bri": lights[str(lightId)]["state"]["bri"]}, lights, addresses, None,)).start()  
+                                    elif operation == 2:
+                                        Thread(target=sendLightRequest, args=(str(lightId), {"xy": lights[str(lightId)]["state"]["xy"]}, lights, addresses, [r,g,b],)).start()
                                 else:
-                                    if frameID == 24: # => every seconds, increase in case the destination device is overloaded
-                                        gottaSend = False
-                                        yee = proto == "yeelight"
-                                        brABS = abs(int((r + b + g) / 3) - lightStatus[lightId]["bri"])
-                                        if r == 0 and g == 0 and b == 0: #Turn off if color is black
+                                    if fremeID % 4 == 0: # can use 2, 4, 6, 8, 12 => increase in case the destination device is overloaded
+                                        if r == 0 and  g == 0 and  b == 0:
                                             if lightStatus[lightId]["on"]:
                                                 sendLightRequest(str(lightId), {"on": False, "transitiontime": 3}, lights, addresses, None, host_ip)
                                                 lightStatus[lightId]["on"] = False
-                                        else:
-                                            if lightStatus[lightId]["on"] == False: #Turn on if color is not black
-                                                sendLightRequest(str(lightId), {"on": True, "transitiontime": 3}, lights, addresses, None, host_ip)
-                                                lightStatus[lightId]["on"] = True
-                                            elif brABS > 50: # to optimize, send brightness only if difference is bigger than this value
-                                                sendLightRequest(str(lightId), {"bri": int((r + b + g) / 3), "transitiontime": 150 / brABS}, lights, addresses, None, host_ip)
-                                                lightStatus[lightId]["bri"] = int((r + b + g) / 3)
-                                            else:
-                                                gottaSend = True
-                                            if gottaSend or yee:
-                                                sendLightRequest(str(lightId), {"xy": convert_rgb_xy(r, g, b), "transitiontime": 3}, lights, addresses, [r, g, b], host_ip)
-                                frameID += 1
-                                if frameID == 25:
-                                    frameID = 0
+                                        elif lightStatus[lightId]["on"] == False:
+                                            sendLightRequest(str(lightId), {"on": True, "transitiontime": 3}, lights, addresses, None, host_ip)
+                                            lightStatus[lightId]["on"] = True
+                                        operation = skipSimilarFrames(lightId, lights[str(lightId)]["state"]["xy"], lights[str(lightId)]["state"]["bri"])
+                                        if operation == 1:
+                                            sendLightRequest(str(lightId), {"bri": lights[str(lightId)]["state"]["bri"], "transitiontime": 3}, lights, addresses, None, host_ip)
+                                        elif operation == 2:
+                                            sendLightRequest(str(lightId), {"xy": lights[str(lightId)]["state"]["xy"], "transitiontime": 3}, lights, addresses)
+                                            
+                                fremeID += 1
+                                if fremeID == 25:
+                                    fremeID = 1
                         i = i + 9
                 elif data[14] == 1: #cie colorspace
                     i = 16
@@ -88,28 +124,43 @@ def entertainmentService(lights, addresses, groups, host_ip):
                                         esphomeLights[addresses[str(lightId)]["ip"]] = {}
                                     r, g, b = convert_xy(x, y, bri)
                                     esphomeLights[addresses[str(lightId)]["ip"]]["color"] = [r, g, b, bri]
+                                elif proto == "mi_box":
+                                    fremeID += 1
+                                    if fremeID % 8 == 0: # can use 2, 4, 6, 8, 12 => increase in case the destination device is overloaded
+                                        operation = skipSimilarFrames(lightId, [x,y], bri)
+                                        if operation == 1:
+                                            Thread(target=sendLightRequest, args=(str(lightId), {"bri": bri}, lights, addresses,)).start()
+                                        elif operation == 2:
+                                            Thread(target=sendLightRequest, args=(str(lightId), {"xy": [x,y]}, lights, addresses,)).start()
                                 else:
-                                    frameID += 1
-                                    if frameID == 24 : #24 = every seconds, increase in case the destination device is overloaded
-                                        sendLightRequest(str(lightId), {"xy": [x,y]}, lights, addresses, None, host_ip)
-                                        frameID = 0
+                                    fremeID += 1
+                                    if fremeID % 4 == 0: # can use 2, 4, 6, 8, 12 => increase in case the destination device is overloaded
+                                        operation = skipSimilarFrames(lightId, [x,y], bri)
+                                        if operation == 1:
+                                            sendLightRequest(str(lightId), {"bri": bri, "transitiontime": 3}, lights, addresses)
+                                        elif operation == 2:
+                                            sendLightRequest(str(lightId), {"xy": [x,y], "transitiontime": 3}, lights, addresses)
+                                fremeID += 1
+                                if fremeID == 25:
+                                    fremeID = 1
+
                         i = i + 9
-            if len(nativeLights) is not 0:
+            if len(nativeLights) != 0:
                 for ip in nativeLights.keys():
                     udpmsg = bytearray()
                     for light in nativeLights[ip].keys():
                         udpmsg += bytes([light]) + bytes([nativeLights[ip][light][0]]) + bytes([nativeLights[ip][light][1]]) + bytes([nativeLights[ip][light][2]])
                     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
                     sock.sendto(udpmsg, (ip.split(":")[0], 2100))
-            if len(esphomeLights) is not 0:
+            if len(esphomeLights) != 0:
                 for ip in esphomeLights.keys():
                     udpmsg = bytearray()
                     udpmsg += bytes([0]) + bytes([esphomeLights[ip]["color"][0]]) + bytes([esphomeLights[ip]["color"][1]]) + bytes([esphomeLights[ip]["color"][2]]) + bytes([esphomeLights[ip]["color"][3]])
                     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
                     sock.sendto(udpmsg, (ip.split(":")[0], 2100))
-        except Exception: #Assuming the only exception is a network timeout, please don't scream at me
+        except Exception as e: #Assuming the only exception is a network timeout, please don't scream at me
             if syncing: #Reset sync status and kill relay service
-                logging.info("Entertainment Service was syncing and has timed out, stopping server and clearing state")
+                logging.info("Entertainment Service was syncing and has timed out, stopping server and clearing state" + str(e))
                 Popen(["killall", "entertain-srv"])
                 for group in groups.keys():
                     if "type" in groups[group] and groups[group]["type"] == "Entertainment":

--- a/BridgeEmulator/protocols/mi_box.py
+++ b/BridgeEmulator/protocols/mi_box.py
@@ -7,207 +7,228 @@ sessionId1 = 0
 sessionId2 = 0
 sock = None
 lastSentMessageTime = 0
+prevOn = False
 
 def set_light(address, light, data, rgb = None):
-	for key, value in data.items():
-		light["state"][key] = value
+    global prevOn
+    
+    # Assign all data elements to the "Object" light.
+    for key, value in data.items():
+        light["state"][key] = value
 
-	on = light["state"]["on"]
-	if on:
-		sendOnCmd(address)
-	colormode = light["state"]["colormode"]
-	if colormode == "xy":
-		xy = light["state"]["xy"]
-		if rgb:
-			r, g, b = rgbBrightness(rgb, light["state"]["bri"])
-		else:
-			r, g, b = convert_xy(xy[0], xy[1], light["state"]["bri"])
-		(hue, saturation, value) = colorsys.rgb_to_hsv(r,g,b)
-		sendHueCmd(address, hue*255)
-		sendSaturationCmd(address, (1-saturation)*100)
-	elif colormode == "ct":
-		ct = light["state"]["ct"]
-		ct01 = (ct - 153) / (500 - 153) #map color temperature from 153-500 to 0-1
-		sendKelvinCmd(address, (1-ct01)*100)
+    on = light["state"]["on"]
+    colormode = light["state"]["colormode"]
+    
+    if (on != prevOn):
+        sendOnCmd(address)
+    
+    if(('xy' in data) or ('ct' in data) or rgb):
+        if (colormode == "xy"):
+            if rgb: # this one is more performant than the "else" block
+                r, g, b = rgbBrightness(rgb, light["state"]["bri"])
+            else:
+                xy = light["state"]["xy"]
+                r, g, b = convert_xy(xy[0], xy[1], light["state"]["bri"])
+            (hue, saturation, value) = colorsys.rgb_to_hsv(r,g,b)
+            sendHueCmd(address, hue*255)
+            sendSaturationCmd(address, (1-saturation)*100)
+        elif colormode == "ct":
+            ct = light["state"]["ct"]
+            ct01 = (ct - 153) / (500 - 153) # map color temperature from 153-500 to 0-1
+            sendKelvinCmd(address, (1-ct01)*100) 
 
-	sendBrightnessCmd(address, (light["state"]["bri"]/255)*100)
-	if not on:
-		sendOffCmd(address)
+    if("bri" in data):
+        sendBrightnessCmd(address, (light["state"]["bri"]/255)*100)
+    
+    if not on:
+        sendOffCmd(address)
+
+    prevOn = on  
+
+def get_lightType(address):
+    light_type = address["light_type"]
+    if(light_type == "rgbcct"):
+        light_type = "rgbww"
+    return light_type
 
 def bytesToHexStr(b):
-	hex_data = binascii.hexlify(b)
-	return hex_data.decode('utf-8')
+    hex_data = binascii.hexlify(b)
+    return hex_data.decode('utf-8')
 
 def sendMsg(address, msg):
-	global sock
-	logging.info("sending udp message to MiLight box:"+bytesToHexStr(msg))
-	if sock is None:
-		logging.info("creating socket")
-		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-		sock.settimeout(0.5)
-		logging.info("connecting to ip")
-		sock.connect((address["ip"], address["port"]))
+    global sock
+    logging.info("sending udp message to MiLight box:"+bytesToHexStr(msg))
+    if sock is None:
+        logging.info("creating socket")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(0.5)
+        logging.info("connecting to ip")
+        sock.connect((address["ip"], address["port"]))
 
-	logging.info("sock.sendall")
-	sock.sendall(msg)
+    logging.info("sock.sendall")
+    sock.sendall(msg)
 
 def closeSocket():
-	global sock, commandCounter, sessionId1, sessionId2, lastSentMessageTime
-	if sock is not None:
-		logging.info("force closing socket connection")
-		sock.close()
-	sock = None
-	sessionId1 = 0
-	sessionId2 = 0
-	commandCounter = 0
+    global sock, commandCounter, sessionId1, sessionId2, lastSentMessageTime
+    if sock is not None:
+        logging.info("force closing socket connection")
+        sock.close()
+    sock = None
+    sessionId1 = 0
+    sessionId2 = 0
+    commandCounter = 0
 
 def sendCmd(address, cmd, tries=3):
-	global sock, commandCounter, sessionId1, sessionId2, lastSentMessageTime
-	logging.info("sendcommand"+bytesToHexStr(cmd))
-	#todo: prevent sending multiple commands at once, this will start the session id request multiple times
+    global sock, commandCounter, sessionId1, sessionId2, lastSentMessageTime
+    logging.info("sendcommand"+bytesToHexStr(cmd))
+    #todo: prevent sending multiple commands at once, this will start the session id request multiple times
 
-	now = time.time()
-	if now - lastSentMessageTime > 10:
-		closeSocket()
-		logging.info("creating new socket connection to MiLight box")
-	lastSentMessageTime = now
+    now = time.time()
+    if now - lastSentMessageTime > 10:
+        closeSocket()
+        logging.info("creating new socket connection to MiLight box")
+    lastSentMessageTime = now
 
-	commandCounter += 1
-	if commandCounter > 255:
-		commandCounter = 0
+    commandCounter += 1
+    if commandCounter > 255:
+        commandCounter = 0
 
-	ip = address["ip"]
-	group = address["group"]
-	light_type = address["light_type"]
+    group = address["group"]
+    light_type = get_lightType(address)
 
-	if sessionId1 == 0 and sessionId2 == 0:
-		if not getSessionId(address):
-			return False
+    if sessionId1 == 0 and sessionId2 == 0:
+        if not getSessionId(address):
+            return False
 
-	msg = b'\x80\x00\x00\x00\x11'
-	msg += bytes([sessionId1, sessionId2])
-	msg += b'\x00'
-	msg += bytes([commandCounter])
-	msg += b'\x00'
-	headersLen = len(msg)
+    msg = b'\x80\x00\x00\x00\x11'
+    msg += bytes([sessionId1, sessionId2])
+    msg += b'\x00'
+    msg += bytes([commandCounter])
+    msg += b'\x00'
+    headersLen = len(msg)
 
-	msg += b'\x31\x00\x00'
-	if light_type == "rgbww":
-		msg += b'\x08'
-	elif light_type == "rgbw":
-		msg += b'\x07'
-	else:
-		msg += b'\x00'
-	msg += cmd
-	msg += bytes([group])
-	msg += b'\x00'
+    msg += b'\x31\x00\x00'
+    if light_type == "rgbww":
+        msg += b'\x08'
+    elif light_type == "rgbw":
+        msg += b'\x07'
+    else:
+        msg += b'\x00'
+    msg += cmd
+    msg += bytes([group])
+    msg += b'\x00'
 
-	#calculate checksum
-	crc = 0
-	for i in range(len(msg) - headersLen):
-		crc = (crc + msg[headersLen+i]) & 255
-	msg += bytes([crc])
+    # calculate checksum
+    crc = 0
+    for i in range(len(msg) - headersLen):
+        crc = (crc + msg[headersLen+i]) & 255
+    msg += bytes([crc])
 
-	sendMsg(address, msg)
-	logging.info("wait for receiving after sending command")
-	data = None
-	try:
-		data, recvAddr = sock.recvfrom(1024)
-	except socket.timeout:
-		logging.info("socket timed out")
-	receiveConfirmed = False
-	if data is not None:
-		logging.info("received "+bytesToHexStr(data))
-		if len(data) == 8 and data[-1] == 0:
-			logging.info("command receive confirmed")
-			receiveConfirmed = True
-	if receiveConfirmed:
-		return
-	if tries > 1:
-		logging.info("retrying sending command")
-		tries -= 1
-		closeSocket()
-		sendCmd(address, cmd, tries)
-	else:
-		raise Exception("sending command failed after 3 tries")
+    sendMsg(address, msg)
+    
+    logging.info("wait for receiving after sending command")
+    data = None
+    try:
+         #pylint: disable=unused-variable
+        data, recvAddr = sock.recvfrom(1024)
+    except socket.timeout:
+        logging.info("socket timed out")
+    receiveConfirmed = False
+    if data is not None:
+        logging.info("received "+bytesToHexStr(data))
+        if len(data) == 8 and data[-1] == 0:
+            logging.info("command receive confirmed")
+            receiveConfirmed = True
+    if receiveConfirmed:
+        return
+    if tries >= 1:
+        logging.info("retrying sending command")
+        tries -= 1
+        closeSocket()
+        sendCmd(address, cmd, tries)
+    else:
+        raise Exception("sending command failed after 3 tries")
 
 def getSessionId(address):
-	global sessionId1, sessionId2
-	sendMsg(address, b'\x20\x00\x00\x00\x16\x02\x62\x3A\xD5\xED\xA3\x01\xAE\x08\x2D\x46\x61\x41\xA7\xF6\xDC\xAF\xD3\xE6\x00\x00\x1E')
-	totalTries = 0
-	while totalTries < 3:
-		totalTries+=1
-		logging.info("wait for receiving session id")
-		data, address = sock.recvfrom(1024)
-		if len(data) == 22:
-			data = bytes(data)
-			sessionId1 = data[19]
-			sessionId2 = data[20]
-			return True
-	return False
+    global sessionId1, sessionId2
+    sendMsg(address, b'\x20\x00\x00\x00\x16\x02\x62\x3A\xD5\xED\xA3\x01\xAE\x08\x2D\x46\x61\x41\xA7\xF6\xDC\xAF\xD3\xE6\x00\x00\x1E')
+    totalTries = 0
+    while totalTries < 3:
+        totalTries+=1
+        logging.info("wait for receiving session id")
+        data, address = sock.recvfrom(1024)
+        if len(data) == 22:
+            data = bytes(data)
+            sessionId1 = data[19]
+            sessionId2 = data[20]
+            return True
+    return False
 
 def sendOnCmd(address):
-	light_type = address["light_type"]
-	cmd = b''
-	if light_type == "rgbww":
-		cmd += b'\x04\x01'
-	elif light_type == "rgbw":
-		cmd += b'\x03\x01'
-	else:
-		cmd += b'\x03\x03'
-	cmd += b'\x00\x00\x00'
-	sendCmd(address, cmd)
+    light_type = get_lightType(address)
+    cmd = b'' 
+    if light_type == "rgbww":
+        cmd += b'\x04\x01'
+    elif light_type == "rgbw":
+        cmd += b'\x03\x01'
+    else:
+        cmd += b'\x03\x03'
+    cmd += b'\x00\x00\x00'
+    sendCmd(address, cmd)
 
 def sendOffCmd(address):
-	light_type = address["light_type"]
-	cmd = b''
-	if light_type == "rgbww":
-		cmd += b'\x04\x02'
-	elif light_type == "rgbw":
-		cmd += b'\x03\x02'
-	else:
-		cmd += b'\x03\x04'
-	cmd += b'\x00\x00\x00'
-	sendCmd(address, cmd)
+    light_type = get_lightType(address)
+    cmd = b''
+    if light_type == "rgbww":
+        cmd += b'\x04\x02'
+    elif light_type == "rgbw":
+        cmd += b'\x03\x02'
+    else:
+        cmd += b'\x03\x04'
+    cmd += b'\x00\x00\x00'
+    sendCmd(address, cmd)
 
 #brightness is between 0-100
 def sendBrightnessCmd(address, brightness):
-	light_type = address["light_type"]
-	cmd = b''
-	if light_type == "rgbww":
-		cmd += b'\x03'
-	elif light_type == "rgbw":
-		cmd += b'\x02'
-	else:
-		cmd += b'\x02'
-	cmd += bytes([int(brightness)])
-	cmd += b'\x00\x00\x00'
-	sendCmd(address, cmd)
+    light_type = get_lightType(address)
+    cmd = b''
+    if light_type == "rgbww":
+        cmd += b'\x03'
+    elif light_type == "rgbw":
+        cmd += b'\x02'
+    else:
+        cmd += b'\x02'
+    cmd += bytes([int(brightness)])
+    cmd += b'\x00\x00\x00'
+    sendCmd(address, cmd, 0)
 
 #hue is between 0-255
 def sendHueCmd(address, hue):
-	cmd = b'\x01'
-	hue = int(hue)
-	cmd += bytes([hue] * 4)
-	sendCmd(address, cmd)
+    cmd = b'\x01'
+    hue = int(hue) + 10 # Color correction.
+    if (hue > 255):
+        hue = hue - 255
+        
+    cmd += bytes([hue] * 4)
+    sendCmd(address, cmd, 0)
 
 #saturation is between 0-100
 def sendSaturationCmd(address, saturation):
-	cmd = b'\x02'
-	#todo: not sure if \x02 works with rgbw and hub lights,
-	#I don't have the hardware so I can't test which bytes are needed here
-	saturation = int(saturation)
-	cmd += bytes([saturation])
-	cmd += b'\x00\x00\x00'
-	sendCmd(address, cmd)
+    cmd = b'\x02'
+    #todo: not sure if \x02 works with rgbw and hub lights,
+    #I don't have the hardware so I can't test which bytes are needed here
+    saturation = int(saturation)
+    cmd += bytes([saturation])
+    cmd += b'\x00\x00\x00'
+    sendCmd(address, cmd, 0)
 
 #kelvin is between 0-100
 def sendKelvinCmd(address, kelvin):
-	cmd = b'\x05'
-	kelvin = int(kelvin)
-	cmd += bytes([kelvin])
-	cmd += b'\x00\x00\x00'
-	sendCmd(address, cmd)
+    cmd = b'\x05'
+    kelvin = int(kelvin)
+    cmd += bytes([kelvin])
+    cmd += b'\x00\x00\x00'
+    sendCmd(address, cmd, 0)
 
 def get_light_state(address, light):
-	return {}
+    return {}


### PR DESCRIPTION
Hey Folks, 

as a result of #487, I decided to work on the issue and try to solve it as best as I can. I'm not a Python dev. If I mess up something pls feel free to fix it on your own. Or tell me what to do. 

I took some essential improvements from the developing branch and merge it with the master branch. Notice that I don't use the Globals.py and some other things, like the "MQTT Entertainment support" is not implementet here.

In this commit, the Entertamentfunction has the "skipSimilarFrames" function and its use before a frame will be sent to the mi_box protocol. 

Furthermore, I notice that 

 ```  Python 
for protocol in protocols:
             protoList[protocol.__name__] = protocol 
```

was called in every  `sendLightRequest([...])`call. It took a lot of time in terms of processing. This is why I made a new method which saves the result.

I changed a lot Inside the mibox protocol. Some CMDS will only be sent if it is necessary which saves time of course. 

Overall Entertainment is now fluent as long you sent the correct params in Milighthub --> Settings --> Radio as follow:

 - Packet repeats: 10
 - Packet repeats per loop: 10
 - Packet repeat throttle threshold: 200
 - Packet repeat throttle sensitivity 0
 - Packet repeat minimum 3
 
You should know that some packets can easily be lost with that config. Otherwise, Entertainment would not work because of the excessive repetition of packets.  While you watch a movie or listen to music it's fine when a frame is lost (In my opinion).

I hope this is helpful. Please try it out and if you think this is useful, merge it to the master branch. 
