### PR TITLE
Set astral version to 2.2 everywhere

### DIFF
--- a/.build/archive/arm.Dockerfile
+++ b/.build/archive/arm.Dockerfile
@@ -5,7 +5,7 @@ RUN [ "cross-build-start" ]
 
 ## Install requirments
 RUN apt update && apt install -y openssl nmap psmisc iproute2 tzdata \
-    && pip install pytz astral==1.6.1 ws4py==0.5.1 requests==2.20.0 paho-mqtt==1.5.0 --no-cache-dir \
+    && pip install pytz astral==2.2 ws4py==0.5.1 requests==2.20.0 paho-mqtt==1.5.0 --no-cache-dir \
     && rm -rf /var/lib/apt/lists/*
 
 ## Install diyHue

--- a/BridgeEmulator/easy_install.sh
+++ b/BridgeEmulator/easy_install.sh
@@ -22,7 +22,7 @@ fi
 
 ### installing astral library for sunrise/sunset routines
 echo -e "\033[36m Installing Python Astral.\033[0m"
-curl -sL https://codeload.github.com/sffjunkie/astral/zip/2.2 -o astral.zip
+curl -sL https://github.com/sffjunkie/astral/archive/2.2.zip -o astral.zip
 unzip -qo astral.zip
 cd astral-2.2/
 python3 setup.py install

--- a/BridgeEmulator/easy_uninstall.sh
+++ b/BridgeEmulator/easy_uninstall.sh
@@ -6,14 +6,14 @@ systemctl stop hue-emulator.service
 
 ### Uninstalling astral library for sunrise/sunset routines
 echo -e "\033[36m Uninstalling Python Astral.\033[0m"
-wget -q https://github.com/sffjunkie/astral/archive/master.zip -O astral.zip
+wget -q https://github.com/sffjunkie/astral/archive/2.2.zip -O astral.zip
 unzip -q -o astral.zip
-cd astral-master/
+cd astral-2.2/
 python3 setup.py install --record files.txt
 # inspect files.txt to make sure it looks ok. Then:
 tr '\n' '\0' < files.txt | xargs -0 sudo rm -f --
 cd ../
-rm -rf astral.zip astral-master/
+rm -rf astral.zip astral-2.2/
 
 ### Uninstalling hue emulator
 echo -e "\033[36m Uninstalling Hue Emulator.\033[0m"

--- a/BridgeEmulator/install_openwrt.sh
+++ b/BridgeEmulator/install_openwrt.sh
@@ -40,15 +40,15 @@ mv /opt/tmp/diyHue/functions/network_OpenWrt.py /opt/hue-emulator/functions/netw
 wait
 cp hueemulatorWrt-service /etc/init.d/
 echo -e "\033[32m Downloading astral.\033[0m"
-wget -q https://github.com/sffjunkie/astral/archive/master.zip -O astral.zip
+wget -q https://github.com/sffjunkie/astral/archive/2.2.zip -O astral.zip
 wait
 unzip -q -o astral.zip
 wait
-cd astral-master/
+cd astral-2.2/
 python3 setup.py install
 wait
 cd ../
-rm -rf astral.zip astral-master/
+rm -rf astral.zip astral-2.2/
 echo -e "\033[32m Download mbedtls to compile binary entertainment.\033[0m"
 wait
 cd /opt/hue-emulator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astral==1.6.1
+astral==2.2
 ws4py==0.5.1
 requests==2.20.0
 paho-mqtt==1.5.0


### PR DESCRIPTION
Some previous work was done in commit a5b6df3
Corresponding code changes were done in commit c8d229a

Without this fix, diyHue throughs import errors, when using motion sensors with the astral library. The code was updated to work with astral 2.2, but not all places where the dependency is specified or installed were updated.