### PR TITLE
Fix concurrent modification [on experimental]

### DIFF
--- a/src/core/lightManager/core/lightRequest.py
+++ b/src/core/lightManager/core/lightRequest.py
@@ -240,7 +240,7 @@ def sendLightRequest(light, data, lights, addresses, rgb = None, entertainmentHo
 def syncWithLights(lights, addresses, users, groups, off_if_unreachable): #update Hue Bridge lights states
     while True:
         logging.info("sync with lights")
-        for light in addresses:
+        for light in list(addresses):
             try:
                 protocol_name = addresses[light]["protocol"]
                 for protocol in protocols:


### PR DESCRIPTION
Fix concurrent modification when a sync happens at the same time as a discover and will kill the sync tread forever.

This ports the fix that is already on dev