### PR TITLE
MQTT improvements (TLS, Plugs, Check availability)

### DIFF
--- a/BridgeEmulator/functions/__init__.py
+++ b/BridgeEmulator/functions/__init__.py
@@ -37,6 +37,14 @@ light_types["LCT015"]["capabilities"] = {"certified": True,"control": {"colorgam
 light_types["LST002"] = {"type": "Color light", "swversion": "5.127.1.26581"}
 light_types["LST002"]["state"] = {"on": False, "bri": 200, "hue": 0, "sat": 0, "xy": [0.0, 0.0], "ct": 461, "alert": "none", "mode": "homeautomation", "effect": "none", "colormode": "ct", "reachable": True}
 light_types["LST002"]["capabilities"] = {"certified": True,"control": {"colorgamut": [[0.704,0.296],[0.2151,0.7106],[0.138,0.08]],"colorgamuttype": "A","maxlumen": 200,"mindimlevel": 10000},"streaming": {"proxy": False,"renderer": True}}
+light_types["LST002"]["config"] = {"archetype": "huelightstrip","direction": "omnidirectional","function": "mixed"}
+
+# Duplicate light strips
+light_types["LST001"] = light_types["LST002"]
+light_types["LST003"] = light_types["LST002"]
+light_types["LCL001"] = light_types["LST002"]
+light_types["LCL002"] = light_types["LST002"]
+
 
 light_types["LWB010"] = {"type": "Dimmable light", "swversion": "1.46.13_r26312", "manufacturername": "Philips"}
 light_types["LWB010"]["state"] = {"on": False, "bri": 254,"alert": "none", "reachable": True}
@@ -48,6 +56,7 @@ light_types["LTW001"]["capabilities"] = {"certified": True,"control": {"mindimle
 
 light_types["Plug 01"] = {"type": "On/Off plug-in unit", "swversion": "V1.04.12"}
 light_types["Plug 01"]["state"] = {"on": False, "alert": "none", "reachable": True}
+light_types["Plug 01"]["config"] = {"archetype": "adapter", "function": "mixed", "direction": "omnidirectional"}
 
 # The Home Assistant below mimic Hue Bulbs to provide better compatability
 # HomeAssistant-RGB is a Hue White + Colour Ambience

--- a/BridgeEmulator/protocols/mqtt.py
+++ b/BridgeEmulator/protocols/mqtt.py
@@ -168,7 +168,7 @@ def discover(bridge_config, new_lights):
             else:
                 # OSRAM Smart+ plug
                 modelid = "Plug 01"
-        
+       
             # Handle Philips manufacturer a little bit more precise
             # you might look here: https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices.js
             if data["device"]["manufacturer"] == 'Philips':
@@ -199,7 +199,7 @@ def discover(bridge_config, new_lights):
             bridge_config["lights"][new_light_id]["type"] = light_types[modelid]["type"]
             bridge_config["lights"][new_light_id]["state"] = light_types[modelid]["state"]
             if "config" in light_types[modelid]:
-            bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
+                bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
             else:
                 bridge_config["lights"][new_light_id]["config"] = {}
             # Add the lights to new lights, so it shows up in the search screen

--- a/BridgeEmulator/protocols/mqtt.py
+++ b/BridgeEmulator/protocols/mqtt.py
@@ -168,7 +168,7 @@ def discover(bridge_config, new_lights):
             else:
                 # OSRAM Smart+ plug
                 modelid = "Plug 01"
-       
+        
             # Handle Philips manufacturer a little bit more precise
             # you might look here: https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices.js
             if data["device"]["manufacturer"] == 'Philips':
@@ -199,7 +199,7 @@ def discover(bridge_config, new_lights):
             bridge_config["lights"][new_light_id]["type"] = light_types[modelid]["type"]
             bridge_config["lights"][new_light_id]["state"] = light_types[modelid]["state"]
             if "config" in light_types[modelid]:
-                bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
+            bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
             else:
                 bridge_config["lights"][new_light_id]["config"] = {}
             # Add the lights to new lights, so it shows up in the search screen

--- a/BridgeEmulator/protocols/mqtt.py
+++ b/BridgeEmulator/protocols/mqtt.py
@@ -4,6 +4,7 @@ import random
 
 # External libraries
 import paho.mqtt.client as mqtt
+import ssl
 
 # internal functions
 from functions import light_types, nextFreeId
@@ -16,22 +17,28 @@ client = mqtt.Client()
 # Configuration stuff
 discoveryPrefix = "homeassistant"
 latestStates = {}
+latestAvail = {}
 discoveredDevices = {}
 
 # on_connect handler (linked to client below)
 def on_connect(client, userdata, flags, rc):
-    logging.debug("MQTT: Connected with result code "+str(rc))
+    logging.info("MQTT: Connected with result code "+str(rc))
 
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.
     # Start autodetection on lights
     autodiscoveryTopic = discoveryPrefix + "/light/+/light/config" # + in topic is wildcard
     client.subscribe(autodiscoveryTopic)
+    # and plugs too
+    autodiscoveryTopic = discoveryPrefix + "/switch/+/switch/config" # + in topic is wildcard
+    client.subscribe(autodiscoveryTopic)
 
 # on_message handler (linked to client below)
 def on_message(client, userdata, msg):
-    if msg.topic.startswith(discoveryPrefix + "/light/"):
+    if msg.topic.startswith(discoveryPrefix):
         on_autodiscovery_light(msg)
+    elif msg.topic == 'zigbee2mqtt/bridge/state' or  msg.topic.endswith("/availability"):
+        on_avail_update(msg)
     else:
         on_state_update(msg)
 
@@ -42,6 +49,16 @@ def on_autodiscovery_light(msg):
     logging.debug(json.dumps(data, indent=4))
     client.subscribe(data['state_topic'])
     discoveredDevices[data['unique_id']] = data;
+    # avail topics
+    for availtopic in data['availability']:
+        if 'topic' in availtopic:
+            logging.info('subscribe avail topic ' + availtopic['topic'])
+            client.subscribe(availtopic['topic'])
+
+def on_avail_update(msg):
+    data = msg.payload
+    logging.info("MQTT: got avail message on " + msg.topic + " = " + str(data.decode("utf-8")))
+    latestAvail[msg.topic] = data.decode("utf-8") 
 
 def on_state_update(msg):
     logging.info("MQTT: got state message on " + msg.topic)
@@ -77,7 +94,29 @@ def set_light(address, light, data):
     client.publish(address['command_topic'], message)
 
 def get_light_state(address, light):
+
+    # bridge avail?
+    if 'zigbee2mqtt/bridge/state' in latestAvail:
+        if latestAvail['zigbee2mqtt/bridge/state'] == "offline":
+            # lightRequest.py overwrites reachable - so raise exeception instead
+            raise Exception("bridge not avail.")
+            return { 'reachable': False }
+
+    # device avail?
+    if address['state_topic']+'/availability' in latestAvail:
+        if latestAvail[address['state_topic']+'/availability'] == "offline":
+            # lightRequest.py overwrites reachable - so raise exeception instead
+            raise Exception("device " + address['state_topic'] + " not avail.")
+            return { 'reachable': False }
+
+    if address['state_topic'] not in latestStates:
+        # lightRequest.py overwrites reachable - so raise exeception instead
+        raise Exception("device " + address['state_topic'] + " state not set yet.")
+        return { 'reachable': False }
+
     if latestStates[address['state_topic']] is None:
+        # lightRequest.py overwrites reachable - so raise exeception instead
+        raise Exception("device " + address['state_topic'] + " state is None!?")
         return { 'reachable': False }
     
     state = { 'reachable': True }
@@ -127,8 +166,28 @@ def discover(bridge_config, new_lights):
             elif light_ct:
                 modelid = "LTW001"
             else:
+                # OSRAM Smart+ plug
                 modelid = "Plug 01"
-        
+       
+            # Handle Philips manufacturer a little bit more precise
+            # you might look here: https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices.js
+            if data["device"]["manufacturer"] == 'Philips':
+                if data["device"]["model"].find('915005106701') >= 0:
+                    # Hue white and color ambiance LightStrip plus
+                    modelid = 'LST002'
+                if data["device"]["model"].find('7299355PH') >= 0:
+                    # Hue white and color ambiance LightStrip 
+                    modelid = 'LST001'
+                if data["device"]["model"].find('9290018187B') >= 0:
+                    # Hue white and color ambiance LightStrip outdoor 
+                    modelid = 'LST003'
+                if data["device"]["model"].find('8718699703424') >= 0:
+                    # Hue white and color ambiance LightStrip plus
+                    modelid = 'LCL001'
+                if data["device"]["model"].find('9290022890') >= 0:
+                    # Hue white and color ambiance LightStrip outdoor 2m 
+                    modelid = 'LCL002'
+
             # Create the light with data from auto discovery
             bridge_config["lights"][new_light_id] = { "name": light_name, "uniqueid": "4a:e0:ad:7f:cf:" + str(random.randrange(0, 99)) + "-1" }
             bridge_config["lights"][new_light_id]["manufacturername"] = data["device"]["manufacturer"]
@@ -139,8 +198,10 @@ def discover(bridge_config, new_lights):
             # Set the type, a default state and possibly a light config
             bridge_config["lights"][new_light_id]["type"] = light_types[modelid]["type"]
             bridge_config["lights"][new_light_id]["state"] = light_types[modelid]["state"]
-            bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
-
+            if "config" in light_types[modelid]:
+                bridge_config["lights"][new_light_id]["config"] = light_types[modelid]["config"]
+            else:
+                bridge_config["lights"][new_light_id]["config"] = {}
             # Add the lights to new lights, so it shows up in the search screen
             new_lights.update({new_light_id: {"name": light_name}})
             
@@ -159,6 +220,25 @@ def mqttServer(config, lights, adresses, sensors):
     if config['discoveryPrefix'] is not None:
         discoveryPrefix = config['discoveryPrefix']
 
+    # defaults for TLS and certs 
+    if 'mqttCaCerts' not in config:
+        config["mqttCaCerts"] = None
+    if 'mqttCertfile' not in config:
+        config["mqttCertfile"] = None
+    if 'mqttKeyfile' not in config:
+        config["mqttKeyfile"] = None
+    if 'mqttTls' not in config:
+        config["mqttTls"] = False
+    if 'mqttTlsInsecure' not in config:
+        config["mqttTlsInsecure"] = False
+    # TLS set? 
+    if config["mqttTls"]:
+        mqttTlsVersion = ssl.PROTOCOL_TLS
+        client.tls_set(ca_certs=config["mqttCaCerts"], certfile=config["mqttCertfile"], keyfile=config["mqttKeyfile"], tls_version=mqttTlsVersion)
+        # allow insecure
+        if config["mqttTlsInsecure"]:
+            client.tls_insecure_set(config["mqttTlsInsecure"])
+
     # Setup handlers
     client.on_connect = on_connect
     client.on_message = on_message
@@ -167,3 +247,4 @@ def mqttServer(config, lights, adresses, sensors):
 
     # start the loop to keep receiving data
     client.loop_start()
+


### PR DESCRIPTION
MQTT improvements: 
- TLS support
- Plugs / Switch  support
- Check availability (if enabled in zigbee2mqtt) for unreachable-state
- detect Lighstripes a litte bit more correct

**Tested with:** 
- Zigbee2MQTT version 1.16.1
- Several Hue Bulbs, Innr and OSRAM Plugs
- Hue-App 3.45.0

**Notes for documentation updates:**

for config.json you need to add for TLS: 


```
        "mqtt": {
            "discoveryPrefix": "homeassistant",
            "enabled": true,
... 
            # set port to 8883 (default)  
            "mqttPort": 8883,
            # set TLS true and - if necessary: allow Insecure certs
            "mqttTls": true,
            "mqttTlsInsecure": false,
            # in case of using certs and keyfiles (optional)
            # if using docker - do not forget to add to volume / mount
            "mqttCaCerts": "<Path to>/ca.crt",
            "mqttCertfile": "<Path to>/<server>.crt",
            "mqttKeyfile": "<Path to>/<server>.key",
...
 ```

for availability checks enable it in availability_timeout as described https://www.zigbee2mqtt.io/information/availability.html

**Sorry** for ignoring whitespaces in mqtt.py :-/ Saw it too late.