### PR TITLE
Return HTTP_PORT from os.getenv() as int

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -87,7 +87,7 @@ else:
 if args.http_port:
     HOST_HTTP_PORT = args.http_port
 elif os.getenv('HTTP_PORT'):
-    HOST_HTTP_PORT = os.getenv('HTTP_PORT')
+    HOST_HTTP_PORT = int(os.getenv('HTTP_PORT'))
 else:
     HOST_HTTP_PORT = 80
 HOST_HTTPS_PORT = 443 # Hardcoded for now


### PR DESCRIPTION
os.getenv always return a string. (line 90)
Port-number in server_class must be an int (line 1990).

This minor change makes sure that HOST_HTTP_PORT is an int when using environment-variable HTTP_PORT to avoid a crash at startup.