### PR TITLE
Load certificate from the same location where it's generated

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1972,7 +1972,7 @@ def run(https, server_class=ThreadingSimpleServer, handler_class=S):
         server_address = (BIND_IP, HOST_HTTPS_PORT)
         httpd = server_class(server_address, handler_class)
         ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        _certfile = cwd + '/cert.pem'
+        _certfile = CONFIG_PATH + '/cert.pem'
         ctx.load_cert_chain(certfile=_certfile)
         ctx.options |= ssl.OP_NO_TLSv1
         ctx.options |= ssl.OP_NO_TLSv1_1


### PR DESCRIPTION
The certificate file used for the HTTPS server is loaded from a different location than where the `dockerSetup` writes it.
While the certificate is generated in the `configPath` (or copied there) the `run` method initializing the https server looks for the certificate in the `cwd` (current working directory).
See [here](https://github.com/diyhue/diyHue/blob/master/BridgeEmulator/functions/docker.py#L14)

In the default docker setup these are usually 2 different locations since the certificate (along with the config) is placed in an `"export"` directory.
see [here](https://github.com/diyhue/diyHue/blob/master/BridgeEmulator/HueEmulator3.py#L101)

Effectively this stops diyHue working with the Hue App.

This might also be the root cause for this [issue](https://github.com/diyhue/diyHue/issues/600) as it's very recent.