### PR TITLE
All tabs no spaces make Python /dev/stdin: line 17: `        1)' boy

### DIFF
--- a/BridgeEmulator/easy_install.sh
+++ b/BridgeEmulator/easy_install.sh
@@ -23,7 +23,7 @@ case $userSelection in
         branchSelection="dev"
         echo -e "Dev selected"
         ;;
-				*)
+	*)
         branchSelection="master"
         echo -e "Master selected"
         ;;


### PR DESCRIPTION
In easy_install.sh row 17 there are tabs before *) which makes the script not run, at least on my VM.