### PR TITLE
Refactor get_light_state of WLED protocol to get the on/off status at the light level

### DIFF
--- a/BridgeEmulator/lights/protocols/wled.py
+++ b/BridgeEmulator/lights/protocols/wled.py
@@ -196,14 +196,15 @@ class WledDevice:
 
     def getSegState(self, seg):
         state = {}
-        data = self.getLightState()['state']['seg'][seg]
-        state['bri'] = data['bri']
-        state['on'] = data['on']
-        state['bri'] = data['bri']
+        data = self.getLightState()['state']
+        seg = data['seg'][seg]
+        state['bri'] = seg['bri']
+        state['on'] = data['on'] # Get on/off at light level
+        state['bri'] = seg['bri']
         # Weird division by zero when a color is 0
-        r = int(data['col'][0][0])+1
-        g = int(data['col'][0][1])+1
-        b = int(data['col'][0][2])+1
+        r = int(seg['col'][0][0])+1
+        g = int(seg['col'][0][1])+1
+        b = int(seg['col'][0][2])+1
         state['xy'] = convert_rgb_xy(r, g, b)
         state["colormode"] = "xy"
         return state


### PR DESCRIPTION
The refactor introduced on #807 needs to be also made on the "get_light_state" to keep the consistency of data.

Because now the WLED protocol change the on/off status at light level (instead of segment) it's also necessary to get the on/off status at the light level (instead of segment).

Related with:
https://github.com/diyhue/diyHue/issues/804