### PR TITLE
Fix send_light_data of WLED protocol to handle properly the alert effect

### DIFF
--- a/BridgeEmulator/lights/protocols/wled.py
+++ b/BridgeEmulator/lights/protocols/wled.py
@@ -114,7 +114,7 @@ def send_light_data(c, light, data):
         elif k == "xy":
             color = convert_xy(v[0], v[1], 255)
             seg["col"] = [[color[0], color[1], color[2]]]
-        elif k == "alert":
+        elif k == "alert" and v != "none":
             state = c.getSegState(light.protocol_cfg['segmentId'])
             c.setBriSeg(0, light.protocol_cfg['segmentId'])
             sleep(0.6)


### PR DESCRIPTION
The current send_light_data of WLED protocol everytime that it receive an attribute "alert" it trigger the effect. But it should do it only if the "alert" value is "select" or "lselect".
I found this issue trough Home Assistant beceause everytime it turn on/off a light it send a request with:
```{ alert: "none" }```
And that request shouldn't trigger the alert effect but it's doing it now.