### PR TITLE
Only log warnings/errors to stderr

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -19,6 +19,7 @@ from pprint import pprint
 
 bridgeConfig = configManager.bridgeConfig.yaml_config
 logging = logManager.logger.get_logger(__name__)
+_ = logManager.logger.get_logger("werkzeug")
 WSGIRequestHandler.protocol_version = "HTTP/1.1"
 app = Flask(__name__, template_folder='flaskUI/templates',static_url_path="/static", static_folder='flaskUI/static')
 api = Api(app)

--- a/BridgeEmulator/logManager/logger.py
+++ b/BridgeEmulator/logManager/logger.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 
 def _get_log_format():
@@ -18,10 +19,19 @@ class Logger:
 
     def _setup_logger(self, name):
         logger = logging.getLogger(name)
-        handler = logging.StreamHandler()
+
+        handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(_get_log_format())
-        logger.setLevel(self.logLevel)
+        handler.setLevel(logging.DEBUG)
+        handler.addFilter(lambda record: record.levelno <= logging.INFO)
         logger.addHandler(handler)
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(_get_log_format())
+        handler.setLevel(logging.WARNING)
+        logger.addHandler(handler)
+
+        logger.setLevel(self.logLevel)
         logger.propagate = False
         return logger
 


### PR DESCRIPTION
Currently all logging information is written to stderr (the python logging default), but this means systemd-journald interprets every log message as an error and sets the log level for messages in the journal accordingly. This patch leaves only warnings and errors logged to stderr, all other messages are logged to stdout.