### PR TITLE
Fix variable reference in HueObjects call

### DIFF
--- a/BridgeEmulator/HueObjects/__init__.py
+++ b/BridgeEmulator/HueObjects/__init__.py
@@ -902,7 +902,7 @@ class EntertainmentConfiguration():
                          "type": "update"
                          }
         streamMessage["id_v1"] = "/groups/" + self.id_v1
-        streamMessage.update(state)
+        streamMessage.update(v2State)
         eventstream.append(streamMessage)
 
     def getObjectPath(self):


### PR DESCRIPTION
When using diyHue in docker (image ID `ghcr.io/diyhue/diyhue/core:armv7-872`, so most recent build at time of writing) via MQTT and Home Assistant, I ran into a lot of log messages like

```
diyhue  | 2022-12-24 21:35:21,919 - services.mqtt - INFO - MQTT Exception | name 'state' is not defined
```

I traced this back to the change proposed in this PR. For me, this fixes the problem and has been running for a couple of days now without issues.