### PR TITLE
Started adding Xiaomi MS-S02/ Aqara P1

### DIFF
--- a/BridgeEmulator/flaskUI/devices/views.py
+++ b/BridgeEmulator/flaskUI/devices/views.py
@@ -8,7 +8,7 @@ from functions.devicesRules import addTradfriDimmer, addTradfriCtRemote, addTrad
 logging = logManager.logger.get_logger(__name__)
 #################
 suportedDevicesRules = ["TRADFRI remote control", "TRADFRI on/off switch", "TRADFRI wireless dimmer"]
-dailightMotionEmulation = ["TRADFRI motion sensor", "lumi.sensor_motion"]
+dailightMotionEmulation = ["TRADFRI motion sensor", "lumi.sensor_motion", "lumi.motion.ac02"]
 #################
 bridgeConfig = configManager.bridgeConfig.yaml_config
 

--- a/BridgeEmulator/services/mqtt.py
+++ b/BridgeEmulator/services/mqtt.py
@@ -27,7 +27,7 @@ latestStates = {}
 discoveredDevices = {}
 
 
-motionSensors = ["TRADFRI motion sensor", "lumi.sensor_motion.aq2", "lumi.sensor_motion", "SML001"]
+motionSensors = ["TRADFRI motion sensor", "lumi.sensor_motion.aq2", "lumi.sensor_motion", "lumi.motion.ac02", "SML001"]
 standardSensors = {
     "TRADFRI remote control": {
         "dataConversion": {


### PR DESCRIPTION
It is a bit of a weird device,

In zigbee2mqtt it is shown as Zigbee Model: `lumi.motion.ac02`
https://www.zigbee2mqtt.io/devices/RTCGQ14LM.html 


Zigbee States:
`{
    "battery": 100,
    "detection_interval": 30,
    "device_temperature": 25,
    "illuminance": 51,
    "linkquality": 90,
    "motion_sensitivity": "medium",
    "occupancy": false,
    "power_outage_count": 1,
    "trigger_indicator": false,
    "voltage": 3173
}`

I started by adding the device to flaskui/devices/views.py and services/mqtt.py.
After that it showed up in HueEssentials. In the Hue app it shows up with the error "not configured in this app".

In DiyHue Web I see it as 3 devices, Hue Motion, Hue Ambient light and Hue Temperature.

When I set a config with HueEssentials and trigger the motion sensor I get this error:
2023-08-04 17:20:23,176 - services.mqtt - INFO - MQTT Exception | 'enabled'

