### PR TITLE
Cert fix for newer Hue App versions

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt ./
 RUN apt update \
     && apt install --no-install-recommends -y \
         curl unzip python3-minimal python3-pip python3-dev python3-setuptools gcc \
-        openssl nmap psmisc iproute2 bluez bluetooth libcoap3-bin \
+        openssl nmap psmisc iproute2 bluez bluetooth libcoap3-bin faketime \
     && pip3 install -r requirements.txt --no-cache-dir --break-system-packages \
     && apt purge -y python3-pip python3-setuptools python3-dev gcc \
     && apt autoremove -y \

--- a/BridgeEmulator/genCert.sh
+++ b/BridgeEmulator/genCert.sh
@@ -2,7 +2,7 @@
 mac=$1
 config="${2:-/opt/hue-emulator/config}"
 dec_serial=`python3 -c "print(int(\"$mac\".strip('\u200e'), 16))"`
-openssl req -new -days 3650 -config /opt/hue-emulator/openssl.conf  -nodes -x509 -newkey  ec -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve   -subj "/C=NL/O=Philips Hue/CN=$mac" -keyout private.key -out public.crt -set_serial $dec_serial
+faketime '2017-01-01 00:00:00' openssl req -new -days 7670 -config /opt/hue-emulator/openssl.conf  -nodes -x509 -newkey  ec -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve   -subj "/C=NL/O=Philips Hue/CN=$mac" -keyout private.key -out public.crt -set_serial $dec_serial
 
 mkdir -p $config
 touch $config/cert.pem

--- a/BridgeEmulator/install.sh
+++ b/BridgeEmulator/install.sh
@@ -38,10 +38,9 @@ generate_certificate () {
 
   echo "Generating certificat for MAC $mac"
   echo -e "\033[33mIf this is a diyhue reinstallation process then you will need to reinstall official Hue apps from PC and phone in order to wipe old certificate.\033[0m"
-  curl https://raw.githubusercontent.com/diyhue/diyHue/9ceed19b4211aa85a90fac9ea6d45cfeb746c9dd/BridgeEmulator/openssl.conf -o openssl.conf
   serial="${mac:0:2}${mac:3:2}${mac:6:2}fffe${mac:9:2}${mac:12:2}${mac:15:2}"
   dec_serial=`python3 -c "print(int(\"$serial\", 16))"`
-  openssl req -new -config openssl.conf  -nodes -x509 -newkey  ec -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve   -subj "/C=NL/O=Philips Hue/CN=$serial" -keyout private.key -out public.crt -set_serial $dec_serial -days 3650
+  faketime '2017-01-01 00:00:00' openssl req -new -config openssl.conf  -nodes -x509 -newkey  ec -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve   -subj "/C=NL/O=Philips Hue/CN=$serial" -keyout private.key -out public.crt -set_serial $dec_serial -days 7670
   if [ $? -ne 0 ] ; then
     echo -e "\033[31m ERROR!! Local certificate generation failed! Attempting remote server generation\033[0m"
     ### test is server for certificate generation is reachable
@@ -98,11 +97,11 @@ esac
 echo -e "\033[36m Installing dependencies.\033[0m"
 if type apt &> /dev/null; then
   # Debian-based distro
-  apt-get install -y unzip python3 python3-pip openssl bluez bluetooth libcoap2-bin
+  apt-get install -y unzip python3 python3-pip openssl bluez bluetooth libcoap2-bin faketime
 elif type pacman &> /dev/null; then
   # Arch linux
   pacman -Syq --noconfirm || exit 1
-  pacman -Sq --noconfirm unzip python3 python-pip gnu-netcat libcoap || exit 1
+  pacman -Sq --noconfirm unzip python3 python-pip gnu-netcat libcoap faketime || exit 1
 else
   # Or assume that packages are already installed (possibly with user confirmation)?
   # Or check them?

--- a/BridgeEmulator/openssl.conf
+++ b/BridgeEmulator/openssl.conf
@@ -11,7 +11,7 @@ x509_extensions = usr_cert
 [ usr_cert ]
 basicConstraints=critical,CA:FALSE
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer
+authorityKeyIdentifier=keyid:always,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All documentation and instructions can be found over at [diyhue.readthedocs.io](
 - coap-client: i.e. via `apt install libcoap2-bin`
 - Python 3
 - Python modules: ws4py, requests, astral, paho-mqtt [see requirements.txt](./requirements.txt)
+- faketime: i.e. via `apt install faketime`
 
  or
 


### PR DESCRIPTION
Newer Hue app versions for iOS and Android are more picky about certificate formatting. This makes the self-signed cert look identical to one generated by a real Gen 2 Hue Bridge.