### PR TITLE
Support geofence_client for aiohue compatibility

### DIFF
--- a/BridgeEmulator/HueObjects/__init__.py
+++ b/BridgeEmulator/HueObjects/__init__.py
@@ -934,6 +934,55 @@ class EntertainmentConfiguration():
         return result
 
 
+class GeofenceClient():
+    def __init__(self, data):
+        self.name = data.get('name', f'Geofence {data.get("id_v1")}')
+        self.id_v2 = data["id_v2"] if "id_v2" in data else genV2Uuid()
+        self.is_at_home = data.get('is_at_home', False)
+
+        streamMessage = {
+            "creationtime": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "data": [self.getV2GeofenceClient()],
+            "id": str(uuid.uuid4()),
+            "type": "add"
+        }
+        eventstream.append(streamMessage)
+
+    def __del__(self):
+        streamMessage = {
+            "creationtime": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "data": [{"id": self.id_v2, "type": "geofence_client"}],
+            "id": str(uuid.uuid4()),
+            "type": "delete"
+        }
+        eventstream.append(streamMessage)
+        logging.info(self.name + " geofence client was destroyed.")
+
+    def update_attr(self, newdata):
+        for key, value in newdata.items():
+            updateAttribute = getattr(self, key)
+            if isinstance(updateAttribute, dict):
+                updateAttribute.update(value)
+                setattr(self, key, updateAttribute)
+            else:
+                setattr(self, key, value)
+
+        streamMessage = {
+            "creationtime": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "data": [self.getV2GeofenceClient()],
+            "id": str(uuid.uuid4()),
+            "type": "update"
+        }
+        eventstream.append(streamMessage)
+
+    def getV2GeofenceClient(self):
+        return {
+            "id": str(uuid.uuid5(uuid.NAMESPACE_URL, self.id_v2 + 'geofence_client')),
+            "name": self.name,
+            "type": "geofence_client"
+        }
+
+
 class Group():
 
     def __init__(self, data):

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -37,7 +37,7 @@ class Config:
             os.makedirs(self.configDir)
 
     def load_config(self):
-        self.yaml_config = {"apiUsers": {}, "lights": {}, "groups": {}, "scenes": {}, "config": {}, "rules": {}, "resourcelinks": {}, "schedules": {}, "sensors": {}, "behavior_instance": {}, "temp": {"eventstream": [], "scanResult": {"lastscan": "none"}, "detectedLights": [], "gradientStripLights": {}}}
+        self.yaml_config = {"apiUsers": {}, "lights": {}, "groups": {}, "scenes": {}, "config": {}, "rules": {}, "resourcelinks": {}, "schedules": {}, "sensors": {}, "behavior_instance": {}, "geofence_clients": {}, "temp": {"eventstream": [], "scanResult": {"lastscan": "none"}, "detectedLights": [], "gradientStripLights": {}}}
         try:
             #load config
             if os.path.exists(self.configDir + "/config.yaml"):

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -459,6 +459,12 @@ class ClipV2Resource(Resource):
                     newObject.add_light(obj)
 
             bridgeConfig["groups"][new_object_id] = newObject
+        else:
+            return {
+                "errors": [{
+                    "description": f"Resource type not supported: {resource}"
+                }]
+            }, 500
 
         # return message
         returnMessage = {"data": [{
@@ -522,7 +528,7 @@ class ClipV2ResourceId(Resource):
                 elif putDict["action"] == "stop":
                     logging.info("stop entertainment")
                     for light in object.lights:
-                        light().update_attr({"state": {"mode": "homeautomation"}}) 
+                        light().update_attr({"state": {"mode": "homeautomation"}})
                     Popen(["killall", "openssl"])
                     object.update_attr({"stream": {"active": False}})
         elif resource == "scene":

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -20,7 +20,8 @@ logging = logManager.logger.get_logger(__name__)
 bridgeConfig = configManager.bridgeConfig.yaml_config
 
 v2Resources = {"light": {}, "scene": {}, "grouped_light": {}, "room": {}, "zone": {
-}, "entertainment": {}, "entertainment_configuration": {}, "zigbee_connectivity": {}, "device": {}, "device_power": {}}
+}, "entertainment": {}, "entertainment_configuration": {}, "zigbee_connectivity": {}, "device": {}, "device_power": {},
+"geofence_client": {}}
 
 
 def getObject(element, v2uuid):
@@ -42,7 +43,7 @@ def getObject(element, v2uuid):
                 v2Resources[element][v2uuid] = weakref.ref(obj)
                 return obj
     else:
-        for v1Element in ["lights", "groups", "scenes", "sensors"]:
+        for v1Element in ["lights", "groups", "scenes", "sensors", "geofence_clients"]:
             for key, obj in bridgeConfig[v1Element].items():
                 if str(uuid.uuid5(uuid.NAMESPACE_URL, obj.id_v2 + element)) == v2uuid:
                     logging.debug("Cache Miss " + element)
@@ -459,6 +460,15 @@ class ClipV2Resource(Resource):
                     newObject.add_light(obj)
 
             bridgeConfig["groups"][new_object_id] = newObject
+        elif resource == 'geofence_client':
+            new_object_id = nextFreeId(bridgeConfig, "geofence_clients")
+            objCreation = {
+                "id_v1": new_object_id,
+                "name": postDict["name"],
+                "type": "geofence_client"
+            }
+            newObject = HueObjects.GeofenceClient(objCreation)
+            bridgeConfig["geofence_clients"][new_object_id] = newObject
         else:
             return {
                 "errors": [{
@@ -561,6 +571,20 @@ class ClipV2ResourceId(Resource):
                         children["rtype"], children["rid"])
                     object.add_light(obj)
             object.update_attr(v1Api)
+        elif resource == 'geofence_client':
+            attrs = {}
+            if "name" in putDict:
+                attrs['name'] = putDict['name']
+            if 'is_at_home' in putDict:
+                attrs['is_at_home'] = putDict['is_at_home']
+            object.update_attr(attrs)
+        else:
+            return {
+                "errors": [{
+                    "description": f"Resource type not supported: {resource}"
+                }]
+            }, 500
+
         response = {"data": [{
             "rid": resourceid,
             "rtype": resource

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -465,7 +465,8 @@ class ClipV2Resource(Resource):
             objCreation = {
                 "id_v1": new_object_id,
                 "name": postDict["name"],
-                "type": "geofence_client"
+                "type": "geofence_client",
+                "is_at_home": postDict.get("is_at_home", False)
             }
             newObject = HueObjects.GeofenceClient(objCreation)
             bridgeConfig["geofence_clients"][new_object_id] = newObject


### PR DESCRIPTION
Fixes #897 by adding just enough functionality to support [aiohue](https://github.com/home-assistant-libs/aiohue)'s (ab)use of a `geofence_client` resource - creating one with a `POST` and periodically updating it with a `PUT`, generating an event for the event stream each time.

In testing I've found that the event stream isn't very reliable at passing messages through to the client - I'm not sure if that's an artefact of my dev environment, but it does eventually settle down if left running for a few minutes.

One addition I'm not sure about is returning an HTTP 500 error to clients when presented with resources through `POST` or `PUT` that diyHue doesn't support, rather than either silently failing or (as was happening in #897) dumping stack traces to the logs. Experience tells me that's usually a better way to handle it, but if any current diyHue clients are relying on the existing behaviour this might cause problems. Happy to back out that part of these changes if you'd prefer.