### PR TITLE
Update __init__.py to fix out of range index values generated by X/Y/Z = 0 Entertainment Areas created by music sync apps

### DIFF
--- a/BridgeEmulator/HueObjects/__init__.py
+++ b/BridgeEmulator/HueObjects/__init__.py
@@ -881,8 +881,9 @@ class EntertainmentConfiguration():
                 if light().modelid in ["LCX001", "LCX002", "LCX003"]:
                     loops = len(gradienStripPositions)
                 elif light().modelid in ["915005987201", "LCX004", "LCX006"]:
-                    loops = 3
+                    loops = len(self.locations[light()])
                 for x in range(loops):
+                    print("x:", x)
                     channel = {
                         "channel_id": channel_id,
                         "members": [


### PR DESCRIPTION
Fixes automatically created entertainment areas containing LCX004/LCX006 Gradient Strips