### PR TITLE
Update HueEmulator3.py to use the default Python version

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 from flask import Flask
 from flask.json import jsonify
 from flask_cors import CORS


### PR DESCRIPTION
Trying to make it easier for future new instals...

The automatic install script is right now using the default python version to install the requirements.txt modules

Because it simply runs "pip3 install -r ../requirements.txt" in the default BASH environment.

Then, if the default python isn't necessarily the "/usr/bin/python3" executable, the Systemctl Service will fail not locating any of the modules.