### PR TITLE
Fixes flaskUI.v2restapi - INFO - element not found!

### DIFF
--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -578,7 +578,8 @@ class ClipV2ResourceId(Resource):
                 attrs['name'] = putDict['name']
             if 'is_at_home' in putDict:
                 attrs['is_at_home'] = putDict['is_at_home']
-            object.update_attr(attrs)
+            if hasattr(object, 'update_attr') and callable(getattr(object, 'update_attr')):
+                object.update_attr(attrs)
         else:
             return {
                 "errors": [{


### PR DESCRIPTION
```
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]: AttributeError: 'bool' object has no attribute 'update_attr'
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     ^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     object.update_attr(attrs)
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/opt/hue-emulator/flaskUI/v2restapi.py", line 581, in put
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:            ^^^^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     resp = meth(*args, **kwargs)
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/usr/local/lib/python3.11/dist-packages/flask_restful/__init__.py", line 582, in dispatch_request
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/usr/local/lib/python3.11/dist-packages/flask/views.py", line 84, in view
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     resp = resource(*args, **kwargs)
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/usr/local/lib/python3.11/dist-packages/flask_restful/__init__.py", line 467, in wrapper
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 1502, in dispatch_request
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:          ^^^^^^^^^^^^^^^^^^^^^^^
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:     rv = self.dispatch_request()
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]:   File "/usr/local/lib/python3.11/dist-packages/flask/app.py", line 1516, in full_dispatch_request
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]: Traceback (most recent call last):
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]: [2023-12-06 15:58:08,156] ERROR in app: Exception on /clip/v2/resource/geofence_client/acabb88f-5a61-5057-9589-b5edebd3cff7>
Dec 06 18:58:08 raspberrypi HueEmulator3.py[1571178]: 2023-12-06 15:58:08,155 - flaskUI.v2restapi - INFO - element not found!
```

"attrs" is frequently being considered a Boolean instead of an Object when "update_attr" is called upon for the 'geofence_client' resource. This complements last weeks fix that started addressing this issue.

We have to make sure to check whether the object has an update_attr attribute and whether it is callable before attempting to call it. This prevents the AttributeError from occurring when trying to call update_attr on an object that doesn't have this method., ensuring that object.update_attr(attrs) is only called if the update_attr attribute is present and is a callable method. 