### PR TITLE
install.sh: fix backup certificate generation method

### DIFF
--- a/BridgeEmulator/install.sh
+++ b/BridgeEmulator/install.sh
@@ -48,7 +48,7 @@ generate_certificate () {
       echo -e "\033[31m ERROR!! Certificate generation service is down. Please try again later.\033[0m"
       exit 1
     fi
-    curl "https://certgen.lightningdark.com/gencert?mac=$mac" > /opt/hue-emulator/cert.pem
+    curl "http://mariusmotea.go.ro:9002/gencert?mac=$mac" > /opt/hue-emulator/cert.pem
   else
     touch /opt/hue-emulator/cert.pem
     cat private.key > /opt/hue-emulator/cert.pem


### PR DESCRIPTION
this should fix the backup cert method from issue #966, hopefully I am doing this correctly.
I tested that this generates and downloads a certificate (unlike currently), but I did not test that said certificate is actually effective.