### PR TITLE
Fix for tasmota lights

### DIFF
--- a/BridgeEmulator/lights/protocols/tasmota.py
+++ b/BridgeEmulator/lights/protocols/tasmota.py
@@ -113,7 +113,7 @@ def get_light_state(light):
             rgb = hex_to_rgb(hex)
             state["xy"] = convert_rgb_xy(rgb[0],rgb[1],rgb[2])
 
-        state["bri"] = (int(light_data["Dimmer"]) / 100.0) * 254.0
+        state["bri"] = int(light_data["Dimmer"] / 100.0 * 254.0)
         state["colormode"] = "xy"
 
     return state


### PR DESCRIPTION
Converts a float value into mandatory int value for the brightness.

Should fix #915 with reported detection and connection/pairing issues between apps and  diyhue bridge 

Perhaps it solves #941 too, because my OpenBeken light works with the modification.