### PR TITLE
Home assistant lights: Fix WARNING - ... is unreachable: 'NoneType' object is not subscriptable

### DIFF
--- a/BridgeEmulator/lights/protocols/homeassistant_ws.py
+++ b/BridgeEmulator/lights/protocols/homeassistant_ws.py
@@ -59,7 +59,7 @@ def translate_homeassistant_state_to_diyhue_state(existing_diy_hue_state, ha_sta
 
     diyhue_state["reachable"] = reachable
     diyhue_state["on"] = is_on
-    if "attributes" in ha_state:
+    if "attributes" in ha_state and is_on:  # Home assistant only reports attributes if light is on
         for key, value in ha_state['attributes'].items():
             if key == "brightness":
                 diyhue_state['bri'] = value


### PR DESCRIPTION
Home assistant only reports attributes if light is on, which currently results in the following error and a 'offline' flag in DiyHue:
`2024-02-07 12:26:55,386 - services.stateFetch - WARNING - lamp.trapkast Light is unreachable: 'NoneType' object is not subscriptable` 

This is mainly caused by: `diyhue_state['xy'] = [value[0], value[1]]`, the other values are set to None currently.

I am not sure what the desired behaviour is:
- Only update these attributes if light is on and a value is returend by Home assistant (this fix).
- Update these attributes with `None`.