### PR TITLE
MQTT: allow selective inclusion of MQTT devices

### DIFF
--- a/BridgeEmulator/services/mqtt.py
+++ b/BridgeEmulator/services/mqtt.py
@@ -214,8 +214,29 @@ def getObject(friendly_name):
         logging.debug("Device not found for " + friendly_name)
         return False
 
+def should_include_device(device_name, device_id):
+    if not bridgeConfig['config']['mqtt']['explicitInclude']:
+        return True
+    return device_name in bridgeConfig['config']['mqtt']['includeList'] or device_id in bridgeConfig['config']['mqtt']['includeList']
+
+def should_include_discovery_device(msg):
+    data = json.loads(msg.payload)
+    if not bridgeConfig['config']['mqtt']['includeGroups'] and data['device']['model'] == "Group":
+        logging.info("Ignoring discovered group on: " + msg.topic)
+        return False
+    
+    if bridgeConfig['config']['mqtt']['explicitInclude']:
+        device_name = data['device']['name']
+        device_id = data['unique_id'].split('_')[0]
+        return should_include_device(device_name, device_id)
+        
+    return True
+
 # Will get called zero or more times depending on how many lights are available for autodiscovery
 def on_autodiscovery_light(msg):
+    if not should_include_discovery_device(msg):
+        return
+
     data = json.loads(msg.payload)
     logging.info("Auto discovery message on: " + msg.topic)
     #logging.debug(json.dumps(data, indent=4))
@@ -258,8 +279,6 @@ def on_autodiscovery_light(msg):
 
             addNewLight(modelid, lightName, "mqtt", protocol_cfg)
 
-
-
 def on_state_update(msg):
     logging.debug("MQTT: got state message on " + msg.topic)
     data = json.loads(msg.payload)
@@ -278,6 +297,11 @@ def on_message(client, userdata, msg):
                 on_autodiscovery_light(msg)
             elif msg.topic == "zigbee2mqtt/bridge/devices":
                 for key in data:
+                    if "friendly_name" in key and "ieee_address" in key:
+                        if not should_include_device(key['friendly_name'], key['ieee_address']):
+                            logging.info("MQTT: bypassing device " + key['friendly_name'])
+                            continue
+
                     if "model_id" in key and (key["model_id"] in standardSensors or key["model_id"] in motionSensors): # Sensor is supported
                         if getObject(key["friendly_name"]) == False: ## Add the new sensor
                             logging.info("MQTT: Add new mqtt sensor " + key["friendly_name"])
@@ -433,6 +457,13 @@ def mqttServer():
         bridgeConfig["config"]["mqtt"]["mqttTls"] = False
     if 'mqttTlsInsecure' not in bridgeConfig["config"]["mqtt"]:
         bridgeConfig["config"]["mqtt"]["mqttTlsInsecure"] = False
+    if 'explicitInclude' not in bridgeConfig["config"]["mqtt"]:
+        bridgeConfig["config"]["mqtt"]["explicitInclude"] = False
+    if 'includeGroups' not in bridgeConfig["config"]["mqtt"]:
+        bridgeConfig["config"]["mqtt"]["includeGroups"] = True
+    if 'includeList' not in bridgeConfig["config"]["mqtt"]:
+        bridgeConfig["config"]["mqtt"]["includeList"] = []
+    
     # TLS set?
     if bridgeConfig["config"]["mqtt"]["mqttTls"]:
         mqttTlsVersion = ssl.PROTOCOL_TLS


### PR DESCRIPTION
It can be helpful if you have a large Z2M network to selectively include devices to be forwarded or bridged by diyHue, especially if you're using it in conjunction with Z2M groups. This patch adds the following configuration options:

- `mqtt.explicitInclude`: this enables the testing for IEEE or Friendly Name found within:
- `mqtt.includeList`: an array of IEEE or Friendly Name strings to allow to be included
- `mqtt.includeGroups`: an easy boolean to disallow forwarding Z2M groups without the additional options

Please let me know if I should also update the documentation or if any other changes need to be made. Thanks again!