### PR TITLE
avoids a float division by zero for tasmota lights, when light is dimmed off

### DIFF
--- a/BridgeEmulator/functions/colors.py
+++ b/BridgeEmulator/functions/colors.py
@@ -21,8 +21,14 @@ def convert_rgb_xy(red, green, blue):
     Z = red * 0.000088 + green * 0.072310 + blue * 0.986039
 
 #Calculate the xy values from the XYZ values
-    x = X / (X + Y + Z)
-    y = Y / (X + Y + Z)
+    div = X + Y + Z
+    if div < 0.000001:
+        # set values to zero in case of div by zero
+        x = 0
+        y = 0
+    else:
+        x = X / div
+        y = Y / div
     return [x, y]
 
 def convert_xy(x, y, bri): #needed for milight hub that don't work with xy values


### PR DESCRIPTION
Added a check for color conversion to avoid a float division by zero.
Function is called from tasmota.py and results in this exception when light is dimmed down to zero

    2024-04-01 15:38:09,297 - services.stateFetch - WARNING - MyLEDStrip is unreachable: float division by zero

This PR is related to #941.