### PR TITLE
Update Group.py

### DIFF
--- a/BridgeEmulator/HueObjects/Group.py
+++ b/BridgeEmulator/HueObjects/Group.py
@@ -137,7 +137,7 @@ class Group():
             if light():
                 if light().state["on"]:
                     any_on = True
-                    bri = bri + light().state["bri"]
+                    bri = bri + light().state.get("bri", 0)
                     lights_on = lights_on + 1
                 else:
                     all_on = False


### PR DESCRIPTION
Fix for KeyError: 'bri'
The error occurred because some lights in a group did not have the bri (brightness) key in their state. To resolve this, the .get() method is used to provide a default value of 0 when bri is not available:

bri = bri + light().state.get("bri", 0)
This ensures that the program doesn't fail when the bri key is missing.