### PR TITLE
Improve shebang compatibility

### DIFF
--- a/.build/startup.sh
+++ b/.build/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n ${1+x} ]; then 
     mac=$1

--- a/BridgeEmulator/check_updates.sh
+++ b/BridgeEmulator/check_updates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Checking for Updates"
 curl -s https://raw.githubusercontent.com/diyhue/diyHue/master/BridgeEmulator/easy_install.sh | sudo bash /dev/stdin

--- a/BridgeEmulator/configManager/argumentHandler.py
+++ b/BridgeEmulator/configManager/argumentHandler.py
@@ -19,7 +19,7 @@ def get_environment_variable(var, boolean=False):
 def generate_certificate(mac, path):
     logging.info("Generating certificate")
     serial = (mac[:6] + "fffe" + mac[-6:]).encode('utf-8')
-    call(["/bin/bash", "/opt/hue-emulator/genCert.sh", serial, path])
+    call(["/usr/bin/env", "bash", "/opt/hue-emulator/genCert.sh", serial, path])
     logging.info("Certificate created")
 
 

--- a/BridgeEmulator/easy_openwrt.sh
+++ b/BridgeEmulator/easy_openwrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo -e "\033[31m Installing diyHue Beta (flask)\033[0m"
 echo -e "\033[32m Deleting folders.\033[0m"
 rm -Rf /opt/hue-emulator

--- a/BridgeEmulator/easy_uninstall.sh
+++ b/BridgeEmulator/easy_uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd /tmp
 
 echo -e "\033[36m Stopping diyHue.\033[0m"

--- a/BridgeEmulator/genCert.sh
+++ b/BridgeEmulator/genCert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mac=$1
 config="${2:-/opt/hue-emulator/config}"
 dec_serial=`python3 -c "print(int(\"$mac\".strip('\u200e'), 16))"`

--- a/BridgeEmulator/install_openwrt.sh
+++ b/BridgeEmulator/install_openwrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\033[32m Updating repository.\033[0m"
 opkg update

--- a/BridgeEmulator/update_openwrt.sh
+++ b/BridgeEmulator/update_openwrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\033[32m Disable startup service.\033[0m"
 /etc/init.d/hueemulatorWrt-service disable


### PR DESCRIPTION
The path `/bin/bash` is not available on all systems, using `/usr/bin/env bash` is preferred for portability.