### PR TITLE
Fix Hue BLE discovery & add support for Hue spot light type

### DIFF
--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -293,7 +293,7 @@ class Light():
                                   "points_capable": self.protocol_cfg["points_capable"]}
 
         # color lights only
-        if self.modelid in ["LST002", "LCT001", "LCT015", "LCX002", "915005987201", "LCX004", "LCX006", "LCA005", "LLC010"]:
+        if self.modelid in ["LST002", "LCT001", "LCT015", "LCX002", "915005987201", "LCX004", "LCX006", "LCA005", "LLC010", "LCG001"]:
             colorgamut = lightTypes[self.modelid]["v1_static"]["capabilities"]["control"]["colorgamut"]
             result["color"] = {
                 "gamut": {

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -75,6 +75,8 @@ class Config:
                     config["tasmota"] = {"enabled": True}
                 if "wled" not in config:
                     config["wled"] = {"enabled": True}
+                if "hue_bl" not in config:
+                    config["hue_bl"] = {"enabled": False}
                 if "shelly" not in config:
                     config["shelly"] = {"enabled": True}
                 if "esphome" not in config:
@@ -133,6 +135,7 @@ class Config:
                     "linkbutton":{"lastlinkbuttonpushed": 1599398980},
                     "users":{"admin@diyhue.org":{"password":"pbkdf2:sha256:150000$bqqXSOkI$199acdaf81c18f6ff2f29296872356f4eb78827784ce4b3f3b6262589c788742"}},
                     "hue": {},
+                    "hue_bl": {"enabled": False},
                     "tradfri": {},
                     "homeassistant": {"enabled":False},
                     "yeelight": {"enabled":True},

--- a/BridgeEmulator/lights/discover.py
+++ b/BridgeEmulator/lights/discover.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Tuple, Union, Generator
-from lights.protocols import tpkasa, wled, mqtt, hyperion, yeelight, hue, deconz, native_multi, tasmota, shelly, esphome, tradfri, elgato, govee
+from lights.protocols import tpkasa, wled, mqtt, hyperion, yeelight, hue, hue_bl, deconz, native_multi, tasmota, shelly, esphome, tradfri, elgato, govee
 from services import homeAssistantWS
 from HueObjects import Light, StreamEvent
 from functions.core import nextFreeId
@@ -198,7 +198,7 @@ def is_light_matching(lightObj: Light.Light, light: Dict) -> bool:
         return lightObj.protocol_cfg["id"] == light["protocol_cfg"]["id"] and lightObj.modelid == light["modelid"]
     if protocol in ["shelly", "native", "native_single", "esphome", "elgato"]:
         return lightObj.protocol_cfg["mac"] == light["protocol_cfg"]["mac"] and lightObj.modelid == light["modelid"]
-    if protocol in ["hue", "deconz"]:
+    if protocol in ["hue", "hue_bl", "deconz"]:
         return lightObj.protocol_cfg["uniqueid"] == light["protocol_cfg"]["uniqueid"] and lightObj.modelid == light["modelid"]
     if protocol == "wled":
         return (lightObj.protocol_cfg["mac"] == light["protocol_cfg"]["mac"] and
@@ -251,6 +251,8 @@ def discover_lights(detectedLights: List[Dict], device_ips: List[str]) -> None:
         wled.discover(detectedLights, device_ips)
     if bridgeConfig["config"]["hue"]:
         hue.discover(detectedLights, bridgeConfig["config"]["hue"])
+    if bridgeConfig["config"]["hue_bl"]["enabled"]:
+        hue_bl.discover(detectedLights)
     if bridgeConfig["config"]["shelly"]["enabled"]:
         shelly.discover(detectedLights, device_ips)
     if bridgeConfig["config"]["esphome"]["enabled"]:

--- a/BridgeEmulator/lights/light_types.py
+++ b/BridgeEmulator/lights/light_types.py
@@ -126,6 +126,15 @@ lightTypes["LOM010"]["state"] = {"on": False,"alert": "select","mode": "homeauto
 lightTypes["LOM010"]["config"] = {"archetype": "plug","function": "functional","direction": "omnidirectional","startup":{"mode": "safety","configured": True}}
 lightTypes["LOM010"]["dynamics"] = {"status": "none", "status_values": ["none"]}
 
+# Hue Spot
+lightTypes["LCG001"] = {"v1_static": {"type":"Extended color light", "manufacturername": "Signify Netherlands B.V.", "swversion": "1.104.2"}}
+lightTypes["LCG001"]["v1_static"]["swupdate"] = {"state": "noupdates","lastinstall": "2020-12-09T19:13:52"}
+lightTypes["LCG001"]["v1_static"]["capabilities"] = {"certified": True,"control": {"colorgamut": [[0.675,0.322],[0.409,0.518],[0.167,0.04]],"colorgamuttype": "B","ct": {"max": 500,"min": 153},"maxlumen": 600,"mindimlevel": 5000},"streaming": {"proxy": False,"renderer": True}}
+lightTypes["LCG001"]["device"] = {"certified": True,"manufacturer_name": "Signify Netherlands B.V.","product_archetype": "sultan_bulb","product_name": "Hue color spot","software_version": "1.104.2"}
+lightTypes["LCG001"]["state"] = {"alert": "none", "bri":0, "colormode": "xy", "effect": "none","hue": 0, "mode": "homeautomation","on": False,"reachable": True, "sat": 0,"xy": [0.408,0.517]}
+lightTypes["LCG001"]["config"] = {"archetype": "sultanbulb","direction": "omnidirectional","function": "mixed","startup": {"configured": True, "mode": "safety"}}
+lightTypes["LCG001"]["dynamics"] = {"speed": 0, "speed_valid": False, "status": "none", "status_values": ["none", "dynamic_palette"]}
+
 
 archetype = {"tableshade":"table_shade",
     "flexiblelamp":"flexible_lamp",

--- a/BridgeEmulator/lights/protocols/hue_bl.py
+++ b/BridgeEmulator/lights/protocols/hue_bl.py
@@ -1,6 +1,6 @@
 import logManager
 import asyncio
-from functions.colors import convert_xy
+from functions.colors import convert_xy, convert_rgb_xy
 logging = logManager.logger.get_logger(__name__)
 Connections = {}
 
@@ -9,10 +9,11 @@ asyncio.set_event_loop(loop)
 
 ### libhueble ###
 ### https://github.com/alexhorn/libhueble/ ###
-from bleak import BleakClient
-from rgbxy import Converter, GamutC, get_light_gamut
+from bleak import BleakClient, BleakScanner
 from struct import pack, unpack
 
+# device name as an ASCII string
+CHAR_NAME = '97fe6561-0003-4f62-86e9-b71ee2da3d22'
 # model number as an ASCII string
 CHAR_MODEL = '00002a24-0000-1000-8000-00805f9b34fb'
 # power state (0 or 1)
@@ -21,6 +22,12 @@ CHAR_POWER = '932c32bd-0002-47a2-835a-a8d455b859dd'
 CHAR_BRIGHTNESS = '932c32bd-0003-47a2-835a-a8d455b859dd'
 # color (CIE XY coordinates converted to two 16-bit little-endian integers)
 CHAR_COLOR = '932c32bd-0005-47a2-835a-a8d455b859dd'
+# temperature
+CHAR_TEMPERATURE = '932c32bd-0004-47a2-835a-a8d455b859dd'
+
+# Bluetooth UUID for Hue lights
+HUE_SERVICE_IDENTIFIER_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
+DISCOVERY_TIMEOUT_SEC = 5
 
 class Lamp(object):
     """A wrapper for the Philips Hue BLE protocol"""
@@ -28,6 +35,8 @@ class Lamp(object):
     def __init__(self, address):
         self.address = address
         self.client = None
+        self.name = None
+        self.model = None
 
     @property
     def is_connected(self):
@@ -35,18 +44,26 @@ class Lamp(object):
 
     async def connect(self):
         # reinitialize BleakClient for every connection to avoid errors
-        self.client = BleakClient(self.address)
+        self.client = BleakClient(self.address, pair=True)
+        logging.debug(f"Connecting to Hue Bluetooth light with address: {self.address}")
         await self.client.connect()
-
-        model = await self.get_model()
-        try:
-            self.converter = Converter(get_light_gamut(model))
-        except ValueError:
-            self.converter = Converter(GamutC)
+        self.name = await self.get_name()
+        self.model = await self.get_model()
+        return self.client.is_connected
 
     async def disconnect(self):
-        await self.client.disconnect()
-        self.client = None
+        try:
+            await self.client.disconnect()
+        except Exception as e:
+            logging.error(f"Error disconnecting from Hue Bluetooth light: {e}")
+        finally:
+            self.client = None
+            Connections[self.address] = None
+
+    async def get_name(self):
+        """Returns the device name"""
+        name = await self.client.read_gatt_char(CHAR_NAME)
+        return name.decode('ascii')
 
     async def get_model(self):
         """Returns the model string"""
@@ -84,13 +101,23 @@ class Lamp(object):
 
     async def get_color_rgb(self):
         """Gets the RGB color as floats between 0.0 and 1.0"""
+        brightness = self.get_brightness()
         x, y = await self.get_color_xy()
-        return self.converter.xy_to_rgb(x, y)
+        return convert_xy(x, y, brightness)
 
     async def set_color_rgb(self, r, g, b):
         """Sets the RGB color from floats between 0.0 and 1.0"""
-        x, y = self.converter.rgb_to_xy(r, g, b)
+        x, y = convert_rgb_xy(r, g, b)
         await self.set_color_xy(x, y)
+
+    def supports_colour_xy(self):
+        return self.client.services.get_characteristic(CHAR_COLOR) is not None
+    
+    def supports_colour_temp(self):
+        return self.client.services.get_characteristic(CHAR_TEMPERATURE) is not None
+    
+    def supports_brightness(self):
+        return self.client.services.get_characteristic(CHAR_BRIGHTNESS) is not None
 
 async def connect(light, reconnect=False):
     ip = light.protocol_cfg["ip"]
@@ -116,7 +143,7 @@ async def set_light_async(light, data, retry=False):
                     color = convert_xy(value[0], value[1], light.state["bri"])
                     await c.set_color_rgb(color[0] / 254, color[1] / 254, color[2] / 254)
                 except Exception as e:
-                    logging.debug(e)
+                    logging.error(e)
     except:
         # reconnect and try again once
         await connect(light, reconnect=True)
@@ -126,8 +153,55 @@ async def set_light_async(light, data, retry=False):
 def set_light(light, data):
     loop.run_until_complete(set_light_async(light, data))
 
-def get_light_state(light):
-    return {}
 
-def discover(detectedLights, credentials):
-    return {}
+async def get_light_state_async(address, retry=False):
+    state = {"on": False}
+    try:
+        bl_light = await connect(address)
+        state["on"] = await bl_light.get_power()
+        state["xy"] = await bl_light.get_color_xy()
+        if bl_light.supports_colour_xy():
+            state["colormode"] = "xy"
+        elif bl_light.supports_colour_temp():
+            state["colormode"] = "ct"
+        elif bl_light.supports_brightness():
+            state["bri"] = await bl_light.get_brightness()
+    except Exception as e:
+        logging.error(e)
+        return { 'reachable': False }
+    return state
+
+def get_light_state(light):
+    return loop.run_until_complete(get_light_state_async(light))
+
+async def discover_lights_async():
+    bl_lights = []
+    devices_and_adv_data_map = await BleakScanner.discover(DISCOVERY_TIMEOUT_SEC, return_adv=True)
+    devices_and_adv_data = devices_and_adv_data_map.values()
+    logging.debug(f"Discovered {len(devices_and_adv_data)} total bluetooth devices")
+    for i, (d, adv) in enumerate(devices_and_adv_data):
+        if (HUE_SERVICE_IDENTIFIER_UUID in adv.service_uuids and d not in bl_lights):
+            logging.debug(f"Discovered Hue bluetooth device: {d} with advertisements: {adv}")
+            bl_lights.append(d)
+    connected_lights = []
+    for bl_light in map(lambda l: Lamp(l.address), bl_lights):
+        is_connected = await bl_light.connect()
+        if is_connected:
+            connected_lights.append(bl_light)
+        else:
+            logging.error(f"Unable to connect to address {bl_light.address}")
+
+    return connected_lights
+
+def discover(detectedLights):
+    logging.debug("hue_bl: <discover> invoked!")
+    try:
+        lights = asyncio.run(discover_lights_async())
+        if len(lights) > 0:
+            logging.debug(f"Discovered {len(lights)} Hue bluetooth light(s)")
+        for l in lights:
+            detectedLights.append({"protocol": "hue_bl", "name": l.name, "modelid": l.model, "protocol_cfg": {"ip": l.address, "modelid": l.model, "id": l.address, "uniqueid": l.address}})        
+    except Exception as e:
+        logging.error(f"Error connecting to BLE light: {e}")
+
+    logging.debug(f"detected_lights: {detectedLights}")

--- a/examples/docker-compose/with-dbus/docker-compose.yml
+++ b/examples/docker-compose/with-dbus/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  diyhue:
+    container_name: diyhue
+    image: diyhue/core:latest
+    volumes:
+      - ./diyHue:/opt/hue-emulator/config
+      - /run/dbus:/run/dbus:ro # set this to /var/run/dbus:/run/dbus:ro if the host system uses /var/run/dbus
+    restart: always
+    privileged: true
+    environment:
+      - DEBUG=false
+      - MAC=dc:a6:32:xx:xx:xx # Hue app will not pair if MAC and IP variable are not set correctly. Must be the mac of the host main interface
+      - IP=192.168.x.x   
+      - TZ=Europe/Berlin

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ zeroconf==0.38.3
 flask_cors
 yeelight
 python-kasa==0.4.1
-bleak
+bleak>=0.21
 rgbxy


### PR DESCRIPTION
This change adds further support for the Hue BL protocol (which is currently disabled by default) and includes an example docker compose file with dbus to enable bluetooth support in containers.