### PR TITLE
Map Hue effects to WLED built-in effects

### DIFF
--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -332,13 +332,15 @@ class Light():
             "effect_values": [
                 "no_effect",
                 "candle",
-                "fire"
+                "fire",
+                "colorloop"
             ],
-            "status": "no_effect",
+            "status": self.effect,
             "status_values": [
                 "no_effect",
                 "candle",
-                "fire"
+                "fire",
+                "colorloop"
             ]
         }
         result["timed_effects"] = {}

--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -1,7 +1,7 @@
 import uuid
 import logManager
 from lights.light_types import lightTypes, archetype
-from lights.protocols import protocols
+from lights.protocols import protocols, wled
 from HueObjects import genV2Uuid, incProcess, v1StateToV2, generate_unique_id, v2StateToV1, StreamEvent
 from datetime import datetime, timezone
 from copy import deepcopy
@@ -343,6 +343,15 @@ class Light():
                 "colorloop"
             ]
         }
+        if self.protocol == "wled":
+            wled_effect_values = [e for e in wled.HUE_EFFECT_TO_WLED_FX if e != "none"]
+            result["effects_v2"] = {
+                "action": {"effect_values": wled_effect_values},
+                "status": {
+                    "effect": self.effect,
+                    "effect_values": wled_effect_values
+                }
+            }
         result["timed_effects"] = {}
         result["identify"] = {}
         result["id"] = self.id_v2

--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -344,7 +344,9 @@ class Light():
             ]
         }
         if self.protocol == "wled":
-            wled_effect_values = [e for e in wled.HUE_EFFECT_TO_WLED_FX if e != "none"]
+            # "none" is a v1-only internal alias for "no_effect"; "sunbeam" is a
+            # silent input alias for "sunrise" (see wled.py) -- neither is advertised.
+            wled_effect_values = [e for e in wled.HUE_EFFECT_TO_WLED_FX if e not in ("none", "sunbeam")]
             result["effects_v2"] = {
                 "action": {"effect_values": wled_effect_values},
                 "status": {

--- a/BridgeEmulator/lights/protocols/wled.py
+++ b/BridgeEmulator/lights/protocols/wled.py
@@ -13,24 +13,27 @@ logging = logManager.logger.get_logger(__name__)
 discovered_lights = []
 Connections = {}
 
-# Hue effect name -> WLED segment parameters (seg.fx/sx/ix/pal). fx IDs and
-# palette IDs come from WLED's stable built-in lists and may need adjusting
-# for other firmware versions. sx/ix are defaults used only when the request
-# doesn't supply dynamics.speed (for sx) -- see send_light_data().
+# Hue effect name -> WLED segment parameters (seg.fx/sx/ix/pal). fx/pal IDs
+# are WLED's real FX_MODE_*/palette constants (verified against WLED's
+# upstream FX.h) and aligned with the equivalent mapping in the netmindz
+# PhilipsHueV2 WLED usermod so all integration paths produce consistent
+# WLED effects. sx/ix are defaults used only when the request doesn't
+# supply dynamics.speed (for sx) -- see send_light_data().
 HUE_EFFECT_TO_WLED_FX = {
-    "no_effect":  {"fx": 0},                                    # Solid
-    "none":       {"fx": 0},                                    # classic v1 API "off" value
-    "candle":     {"fx": 88,  "sx": 128, "ix": 128},             # Candle
-    "fire":       {"fx": 45,  "sx": 128, "ix": 128, "pal": 35},  # Fire Flicker + Fire palette
-    "colorloop":  {"fx": 8,   "sx": 128, "ix": 128},             # Colorloop
-    "sparkle":    {"fx": 20,  "sx": 128, "ix": 128},             # Sparkle
-    "glisten":    {"fx": 22,  "sx": 180, "ix": 200},             # Sparkle+, faster/more intense per Hue's own description
-    "prism":      {"fx": 67,  "sx": 128, "ix": 128, "pal": 12},  # Colorwaves + Rainbow Bands palette
-    "opal":       {"fx": 75,  "sx": 60,  "ix": 100, "pal": 20},  # Lake + Pastel palette, slow and gentle
-    "cosmos":     {"fx": 2,   "sx": 40,  "ix": 128},             # Breathe (slow), pulses base colour off<->full per Hue's description
-    "sunbeam":    {"fx": 166, "sx": 128, "ix": 128, "pal": 13},  # Sun Radiation + Sunset palette
-    "enchant":    {"fx": 51,  "sx": 100, "ix": 128, "pal": 59},  # Fairytwinkle + Fairy Reaf palette
-    "underwater": {"fx": 101, "sx": 80,  "ix": 128, "pal": 9},   # Pacifica + Ocean palette
+    "no_effect":  {"fx": 0},                                     # Solid (FX_MODE_STATIC)
+    "none":       {"fx": 0},                                     # classic v1 API "off" value
+    "candle":     {"fx": 102, "sx": 128, "ix": 128, "pal": 2},    # Candle Multi (FX_MODE_CANDLE_MULTI) + Color 1 -- NOT plain Candle (88), which has a WLED bug: dereferences uninitialised data on first call after a mode change
+    "fire":       {"fx": 66,  "sx": 128, "ix": 128, "pal": 2},    # Fire 2012 (FX_MODE_FIRE_2012) + Color 1
+    "colorloop":  {"fx": 8,   "sx": 128, "ix": 128},              # Rainbow (FX_MODE_RAINBOW) -- classic v1 API "colorloop"; WLED has no effect literally named "Colorloop"
+    "sparkle":    {"fx": 20,  "sx": 128, "ix": 128, "pal": 2},    # Sparkle (FX_MODE_SPARKLE) + Color 1
+    "prism":      {"fx": 9,   "sx": 128, "ix": 128},              # Rainbow Cycle (FX_MODE_RAINBOW_CYCLE) -- uses its own colours
+    "opal":       {"fx": 2,   "sx": 60,  "ix": 100, "pal": 2},    # Breath (FX_MODE_BREATH) + Color 1, slow and gentle
+    "glisten":    {"fx": 80,  "sx": 180, "ix": 200, "pal": 2},    # Twinkle Fox (FX_MODE_TWINKLEFOX) + Color 1, faster/more intense per Hue's own description
+    "sunrise":    {"fx": 104, "sx": 128, "ix": 128},              # Sunrise (FX_MODE_SUNRISE) -- uses its own colours; this is the field name observed on the wire by sibling usermods
+    "sunbeam":    {"fx": 104, "sx": 128, "ix": 128},              # alias for "sunrise" in case the Bridge sends this name instead -- not advertised (see Light.py)
+    "cosmos":     {"fx": 2,   "sx": 40,  "ix": 128, "pal": 2},    # Breath (FX_MODE_BREATH) + Color 1, pulses base colour off<->full per Hue's description
+    "enchant":    {"fx": 51,  "sx": 100, "ix": 128, "pal": 2},    # Fairytwinkle (FX_MODE_FAIRYTWINKLE) + Color 1, whimsical multicolor twinkle
+    "underwater": {"fx": 101, "sx": 80,  "ix": 128},              # Pacifica (FX_MODE_PACIFICA) -- uses its own ocean-themed colours
 }
 
 

--- a/BridgeEmulator/lights/protocols/wled.py
+++ b/BridgeEmulator/lights/protocols/wled.py
@@ -13,14 +13,24 @@ logging = logManager.logger.get_logger(__name__)
 discovered_lights = []
 Connections = {}
 
-# Hue effect name -> WLED built-in effect ID (seg.fx). IDs come from WLED's
-# stable built-in effect list and may need adjusting for other firmware versions.
+# Hue effect name -> WLED segment parameters (seg.fx/sx/ix/pal). fx IDs and
+# palette IDs come from WLED's stable built-in lists and may need adjusting
+# for other firmware versions. sx/ix are defaults used only when the request
+# doesn't supply dynamics.speed (for sx) -- see send_light_data().
 HUE_EFFECT_TO_WLED_FX = {
-    "no_effect": 0,   # Solid
-    "none": 0,        # classic v1 API "off" value
-    "candle": 88,      # Candle
-    "fire": 45,        # Fire Flicker
-    "colorloop": 8,    # Colorloop
+    "no_effect":  {"fx": 0},                                    # Solid
+    "none":       {"fx": 0},                                    # classic v1 API "off" value
+    "candle":     {"fx": 88,  "sx": 128, "ix": 128},             # Candle
+    "fire":       {"fx": 45,  "sx": 128, "ix": 128, "pal": 35},  # Fire Flicker + Fire palette
+    "colorloop":  {"fx": 8,   "sx": 128, "ix": 128},             # Colorloop
+    "sparkle":    {"fx": 20,  "sx": 128, "ix": 128},             # Sparkle
+    "glisten":    {"fx": 22,  "sx": 180, "ix": 200},             # Sparkle+, faster/more intense per Hue's own description
+    "prism":      {"fx": 67,  "sx": 128, "ix": 128, "pal": 12},  # Colorwaves + Rainbow Bands palette
+    "opal":       {"fx": 75,  "sx": 60,  "ix": 100, "pal": 20},  # Lake + Pastel palette, slow and gentle
+    "cosmos":     {"fx": 2,   "sx": 40,  "ix": 128},             # Breathe (slow), pulses base colour off<->full per Hue's description
+    "sunbeam":    {"fx": 166, "sx": 128, "ix": 128, "pal": 13},  # Sun Radiation + Sunset palette
+    "enchant":    {"fx": 51,  "sx": 100, "ix": 128, "pal": 59},  # Fairytwinkle + Fairy Reaf palette
+    "underwater": {"fx": 101, "sx": 80,  "ix": 128, "pal": 9},   # Pacifica + Ocean palette
 }
 
 
@@ -125,12 +135,18 @@ def send_light_data(c, light, data):
             color = convert_xy(v[0], v[1], 255)
             seg["col"] = [[color[0], color[1], color[2]]]
         elif k == "effect":
-            fx = HUE_EFFECT_TO_WLED_FX.get(v)
-            if fx is not None:
-                seg["fx"] = fx
+            effect_cfg = HUE_EFFECT_TO_WLED_FX.get(v)
+            if effect_cfg is not None:
+                seg["fx"] = effect_cfg["fx"]
+                if "pal" in effect_cfg:
+                    seg["pal"] = effect_cfg["pal"]
                 speed = light.dynamics.get("speed")
                 if speed:
                     seg["sx"] = round(clamp(speed, 0, 1) * 255)
+                elif "sx" in effect_cfg:
+                    seg["sx"] = effect_cfg["sx"]
+                if "ix" in effect_cfg:
+                    seg["ix"] = effect_cfg["ix"]
             else:
                 logging.warning("<WLED> Unknown Hue effect '%s', ignoring", v)
         elif k == "alert" and v != "none":

--- a/BridgeEmulator/lights/protocols/wled.py
+++ b/BridgeEmulator/lights/protocols/wled.py
@@ -13,6 +13,16 @@ logging = logManager.logger.get_logger(__name__)
 discovered_lights = []
 Connections = {}
 
+# Hue effect name -> WLED built-in effect ID (seg.fx). IDs come from WLED's
+# stable built-in effect list and may need adjusting for other firmware versions.
+HUE_EFFECT_TO_WLED_FX = {
+    "no_effect": 0,   # Solid
+    "none": 0,        # classic v1 API "off" value
+    "candle": 88,      # Candle
+    "fire": 45,        # Fire Flicker
+    "colorloop": 8,    # Colorloop
+}
+
 
 def on_mdns_discover(zeroconf, service_type, name, state_change):
     global discovered_lights
@@ -114,6 +124,15 @@ def send_light_data(c, light, data):
         elif k == "xy":
             color = convert_xy(v[0], v[1], 255)
             seg["col"] = [[color[0], color[1], color[2]]]
+        elif k == "effect":
+            fx = HUE_EFFECT_TO_WLED_FX.get(v)
+            if fx is not None:
+                seg["fx"] = fx
+                speed = light.dynamics.get("speed")
+                if speed:
+                    seg["sx"] = round(clamp(speed, 0, 1) * 255)
+            else:
+                logging.warning("<WLED> Unknown Hue effect '%s', ignoring", v)
         elif k == "alert" and v != "none":
             state = c.getSegState(light.protocol_cfg['segmentId'])
             c.setBriSeg(0, light.protocol_cfg['segmentId'])


### PR DESCRIPTION
## Summary
- Adds a Hue-effect-to-WLED-effect mapping for WLED lights (previously the `effect` field was silently dropped by the WLED protocol driver).
- Covers the classic vocabulary (`no_effect`/`none`/`candle`/`fire`/`colorloop`) plus Signify's newer CLIP v2 gradient-effect vocabulary (`sparkle`, `prism`, `opal`, `glisten`, `cosmos`, `sunrise`/`sunbeam`, `enchant`, `underwater`), advertised via a proper `effects_v2` resource on WLED lights so they're selectable from the Hue app.
- Each mapping entry sets WLED's `fx` (effect), and where useful `pal` (palette) and default `sx`/`ix` (speed/intensity); `dynamics.speed`, when supplied by the client, overrides the default speed.
- `fx`/palette IDs were verified against WLED's upstream `FX.h` and aligned with the equivalent mapping in the [netmindz/WLED-MM `PhilipsHueV2` usermod](https://github.com/netmindz/WLED-MM/blob/copilot/create-usermod-phillips-hue-v2/usermods/PhilipsHueV2/PhilipsHueV2.cpp) so this integration path and the native-firmware ones produce consistent WLED effects for the same Hue effect name. In the process this avoids a known WLED bug (`FX_MODE_CANDLE` (88) can crash on first call after a mode change — uses `FX_MODE_CANDLE_MULTI` (102) instead) and a 2D-only effect that would have silently no-op'd on normal 1D strips.

## Test plan
- [x] `python3 -m py_compile` on both changed files
- [x] Unit-level exercise of `send_light_data()` against a mocked `WledDevice`/`Light` for each effect name, confirming the expected `fx`/`pal`/`sx`/`ix` are sent, colour (`xy`/`ct`) still passes through alongside an effect, `dynamics.speed` overrides the default `sx`, and unknown effect names log a warning without crashing
- [x] Unit-level exercise of `Light.getV2Api()` confirming `effects_v2` is present (with all 12 real effect names, internal aliases hidden) for `protocol == "wled"` lights and absent for other protocols
- [ ] Not yet verified against a physical/simulated WLED device — would appreciate a test against real hardware before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwEktbsR6R2pFQJJYFEw96