### PR TITLE
Fix incorrect group light state events

### DIFF
--- a/BridgeEmulator/HueObjects/Group.py
+++ b/BridgeEmulator/HueObjects/Group.py
@@ -194,44 +194,15 @@ class Group():
 
 
     def genStreamEvent(self, v2State):
-        streamMessage = {"creationtime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                               "data": [],
-                                 "id": str(uuid.uuid4()),
-                                 "type": "update"
-                                 }
-        for num, device in enumerate(self.lights):
-            if device():
-                # Handle both Device objects (with group_v1) and Light objects (without group_v1)
-                if hasattr(device(), 'group_v1') and device().group_v1 == "lights":
-                    # It's a Device object, get the light from it
-                    light = device().firstElement()
-                    streamMessage["data"].insert(num,{
-                        "id": light.id_v2,
-                        "id_v1": "/lights/" + light.id_v1,
-                        "owner": {
-                            "rid": self.id_v2,
-                            "rtype":"device"
-                        },
-                        "service_id": light.protocol_cfg["light_nr"]-1 if "light_nr" in light.protocol_cfg else 0,
-                        "type": "light"
-                    })
-                    streamMessage["data"][num].update(v2State)
-                elif hasattr(device(), 'id_v2') and not hasattr(device(), 'group_v1'):
-                    # It's a Light object directly
-                    streamMessage["data"].insert(num,{
-                        "id": device().id_v2,
-                        "id_v1": "/lights/" + device().id_v1,
-                        "owner": {
-                            "rid": self.id_v2,
-                            "rtype":"device"
-                        },
-                        "service_id": device().protocol_cfg["light_nr"]-1 if "light_nr" in device().protocol_cfg else 0,
-                        "type": "light"
-                    })
-                    streamMessage["data"][num].update(v2State)
-        StreamEvent(streamMessage)
+        # Do not mirror one light state onto every light in the group.
+        # Individual light events are already emitted by Light.genStreamEvent().
+        v2State = dict(v2State)
+
         if "on" in v2State:
-            v2State["dimming"] = {"brightness": self.update_state()["avr_bri"]}
+            group_state = self.update_state()
+            v2State["on"] = {"on": group_state["any_on"]}
+            v2State["dimming"] = {"brightness": group_state["avr_bri"]}
+
         streamMessage = {"creationtime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                          "data": [{"id": self.id_v2,"id_v1": "/groups/" + self.id_v1, "type": "grouped_light",
                                    "owner": {


### PR DESCRIPTION
This fixes incorrect Hue V2 light state events generated for grouped MQTT lights.

When an individual MQTT light changes state, streamGroupEvent() calls Group.genStreamEvent() for every room/zone containing that light.

Previously, Group.genStreamEvent() applied the individual light’s v2State to every light in the group. This caused Hue clients to receive incorrect ON/OFF updates for unrelated lights in the same room or zone.

I reproduced this with Zigbee2MQTT + Home Assistant + diyHue and captured the /eventstream/clip/v2 output. A state change for one light produced a multi-light event where all lights in the associated room/zone received the same state.

This change:

* stops generating individual light events from Group.genStreamEvent()
* leaves individual light events to Light.genStreamEvent()
* keeps the grouped_light event
* calculates the grouped ON state from update_state()["any_on"]
* calculates grouped brightness from the actual group state

After applying the change, individual ON/OFF events were only generated for the actual light that changed and the incorrect multi-light events disappeared.

Related to #883.