### PR TITLE
Fix V2 event stream delivery for multiple clients

### DIFF
--- a/BridgeEmulator/HueObjects/__init__.py
+++ b/BridgeEmulator/HueObjects/__init__.py
@@ -1,12 +1,38 @@
 import uuid
 import logManager
 import random
+from threading import Lock
 
 logging = logManager.logger.get_logger(__name__)
 
 eventstream = []
+_eventstream_seq = 0
+
+_eventstream_lock = Lock()
+
 def StreamEvent(message):
-    eventstream.append(message)
+    global _eventstream_seq
+
+    with _eventstream_lock:
+        _eventstream_seq += 1
+        eventstream.append((_eventstream_seq, message))
+
+        # Keep a bounded history so slower clients can catch up
+        # without allowing memory usage to grow indefinitely.
+        if len(eventstream) > 2000:
+            del eventstream[:-2000]
+
+def EventStreamSequence():
+    with _eventstream_lock:
+        return _eventstream_seq
+
+def EventStreamSnapshot(after_seq):
+    with _eventstream_lock:
+        return [
+            (seq, message)
+            for seq, message in eventstream
+            if seq > after_seq
+        ]
 
 def v1StateToV2(v1State):
     v2State = {}

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -590,9 +590,9 @@ class ClipV2Resource(Resource):
                         bridge_home_data
                     ]
                     
-                    # Send combined message directly to event stream to avoid double wrapping
-                    import HueObjects
-                    HueObjects.eventstream.append(combined_message)
+                    # Send the combined message through the shared event stream
+                    # so all connected clients can consume it independently.
+                    StreamEvent(combined_message)
                     logging.debug(f"Combined event message sent successfully")
                 else:
                     logging.warning("Could not create bridge_home data, falling back to separate events")

--- a/BridgeEmulator/services/eventStreamer.py
+++ b/BridgeEmulator/services/eventStreamer.py
@@ -8,31 +8,44 @@ logging = logManager.logger.get_logger(__name__)
 stream = Blueprint('stream', __name__)
 
 def messageBroker():
+    # Events are retained in a bounded sequence history.
+    # Do not clear them globally because connected clients may
+    # not have consumed them yet.
     while True:
-        if len(HueObjects.eventstream) > 0:
-            for event in HueObjects.eventstream:
-                logging.debug(event)
-            sleep(0.3)  # ensure all devices connected receive the events
-            HueObjects.eventstream = []
-        sleep(0.2)
+        sleep(60)
 
 @stream.route('/eventstream/clip/v2')
 def streamV2Events():
     def generate():
-        counter = 2000 # 400 seconds
-        yield f": hi\n\n"
-        while counter > 0:  # ensure we stop at some point
-            if len(HueObjects.eventstream) > 0:
-                for index, messages in enumerate(HueObjects.eventstream):
-                    # Check if messages is already an array (combined message)
-                    if isinstance(messages, list):
-                        # It's already an array, don't wrap it again
-                        yield f"id: {int(time()) }:{index}\ndata: {json.dumps(messages, separators=(',', ':'))}\n\n"
-                    else:
-                        # Single message, wrap it in an array
-                        yield f"id: {int(time()) }:{index}\ndata: {json.dumps([messages], separators=(',', ':'))}\n\n"
-                sleep(0.2)
-            sleep(0.2)
-            counter -= 1
+        # Each client tracks its own position in the event history.
+        last_seq = HueObjects.EventStreamSequence()
+        last_heartbeat = time()
 
-    return Response(stream_with_context(generate()), mimetype='text/event-stream; charset=utf-8')
+        yield ": hi\n\n"
+
+        while True:
+            events = HueObjects.EventStreamSnapshot(last_seq)
+
+            for seq, messages in events:
+                if isinstance(messages, list):
+                    payload = messages
+                else:
+                    payload = [messages]
+
+                yield (
+                    f"id: {seq}\n"
+                    f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+                )
+
+                last_seq = seq
+
+            if time() - last_heartbeat >= 15:
+                yield ": keepalive\n\n"
+                last_heartbeat = time()
+
+            sleep(0.1)
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype='text/event-stream; charset=utf-8'
+    )


### PR DESCRIPTION
This fixes a race condition in the Hue V2 event stream delivery.

The current implementation stores events in a single global HueObjects.eventstream list while a separate messageBroker() thread periodically clears that list:

sleep(0.3)
HueObjects.eventstream = []

At the same time, each /eventstream/clip/v2 client independently polls the same global list.

This means an event can be removed before a connected Hue client has consumed it, which can leave the client showing stale light state even though the backend state is already correct.

I reproduced this while testing diyHue with Zigbee2MQTT, Home Assistant and the Philips Hue app.

This change:

* assigns a monotonically increasing sequence number to every event
* keeps a bounded history of the latest 2000 events
* lets each connected SSE client maintain its own last_seq
* prevents one global cleanup operation from removing events before another client has consumed them
* adds periodic SSE keepalive comments
* routes combined room/zone events through StreamEvent() instead of appending directly to the global list
* preserves the existing behavior where combined events are sent as arrays without extra wrapping

After applying this locally, state synchronization in the Hue app became reliable when lights were changed externally through Home Assistant/Zigbee2MQTT.

This was tested together with the group state event fix submitted separately in #1108.

Related to #883.