### PR TITLE
Improve dynamic scene speed and stop handling

### DIFF
--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -92,6 +92,17 @@ class Light():
 
     def setV1State(self, state, advertise=True):
         if "lights" not in state:
+
+            # OFF must terminate a dynamic scene regardless of
+            # whether the command arrived through V1, V2 or a group.
+            # Otherwise the scene worker can send another colour/
+            # brightness command after OFF and wake the lamp again.
+            if (
+                state.get("on") is False
+                and self.dynamics["status"] == "dynamic_palette"
+            ):
+                self.dynamics["status"] = "none"
+
             state = incProcess(self.state, state)
             self.updateLightState(state)
             for key, value in state.items():
@@ -127,6 +138,16 @@ class Light():
 
     def setV2State(self, state):
         v1State = v2StateToV1(state)
+
+        # Native Hue behaviour: manually switching the light off
+        # terminates a running dynamic scene for this light.
+        if (
+            "on" in state
+            and state["on"].get("on") is False
+            and self.dynamics["status"] == "dynamic_palette"
+        ):
+            self.dynamics["status"] = "none"
+
         if "effects_v2" in state and "action" in state["effects_v2"]:
             v1State["effect"] = state["effects_v2"]["action"]["effect"]
             self.effect = v1State["effect"]
@@ -278,9 +299,27 @@ class Light():
         logging.debug("Start Dynamic scene play for " + self.name)
         if "dynamic_palette" in self.dynamics["status_values"]:
             self.dynamics["status"] = "dynamic_palette"
-        while self.dynamics["status"] == "dynamic_palette":
-            transition = int(30 / self.dynamics["speed"])
-            logging.debug("using transistiontime " + str(transition))
+        while (
+            self.dynamics["status"] == "dynamic_palette"
+            and self.state.get("on", True)
+        ):
+            try:
+                current_speed = float(self.dynamics["speed"])
+            except (TypeError, ValueError):
+                current_speed = 0.6269841194152832
+
+            # diyHue's existing Hue-like timing model.
+            # Avoid division by zero but otherwise preserve Hue's
+            # incoming dynamics.speed value unchanged.
+            current_speed = max(0.01, current_speed)
+            transition = max(1, int(30 / current_speed))
+
+            logging.debug(
+                "Dynamic scene %s speed %.4f transition %.1fs",
+                self.name,
+                current_speed,
+                transition / 10
+            )
             if self.modelid in ["LCT001", "LCT015", "LST002", "LCX002", "915005987201", "LCX004", "LCX006", "LCA005"]:
                 if index == len(palette["color"]):
                     index = 0
@@ -312,7 +351,40 @@ class Light():
                 lightState = palette["dimming"][index]
                 lightState["transitiontime"] = transition
                 self.setV2State(lightState)
-            sleep(transition / 10)
+            # Wait in short slices instead of one long sleep.
+            # This lets Hue speed changes and OFF commands take effect
+            # immediately instead of after the current transition.
+            remaining = transition / 10
+
+            while (
+                remaining > 0
+                and self.dynamics["status"] == "dynamic_palette"
+                and self.state.get("on", True)
+            ):
+                try:
+                    new_speed = max(
+                        0.01,
+                        float(self.dynamics["speed"])
+                    )
+                except (TypeError, ValueError):
+                    new_speed = current_speed
+
+                # Hue changed the live speed: recalculate immediately.
+                if abs(new_speed - current_speed) > 0.0001:
+                    break
+
+                chunk = min(0.1, remaining)
+                sleep(chunk)
+                remaining -= chunk
+
+            # OFF or scene deactivation means the worker is finished.
+            if (
+                self.dynamics["status"] != "dynamic_palette"
+                or not self.state.get("on", True)
+            ):
+                self.dynamics["status"] = "none"
+                break
+
             index += 1
             logging.debug("Step forward dynamic scene " + self.name)
         logging.debug("Dynamic Scene " + self.name + " stopped.")

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -724,14 +724,51 @@ class ClipV2ResourceId(Resource):
                     Popen(["killall", "openssl"])
                     object.update_attr({"stream": {"active": False}})
         elif resource == "scene":
-            if "recall" in putDict:
-                object.activate(putDict)
+            # Hue scene speed is 0.0..1.0. Apply it BEFORE recall
+            # and propagate changes to an already running dynamic scene.
             if "speed" in putDict:
-                object.speed = putDict["speed"]
+                try:
+                    requested_speed = max(
+                        0.0,
+                        min(1.0, float(putDict["speed"]))
+                    )
+                    object.speed = requested_speed
+
+                    for light_ref in object.lights:
+                        light = light_ref()
+                        if (
+                            light
+                            and light.dynamics["status"]
+                                == "dynamic_palette"
+                        ):
+                            # diyHue's existing scene player divides by
+                            # speed; treat zero as essentially stationary
+                            # rather than raising ZeroDivisionError.
+                            light.dynamics["speed"] = max(
+                                requested_speed,
+                                0.01
+                            )
+                except (TypeError, ValueError):
+                    pass
+
+            if "recall" in putDict:
+                # Scene.activate() copies object.speed to every light.
+                # Preserve API speed=0 while supplying a safe execution
+                # floor to diyHue's current 30/speed implementation.
+                original_speed = object.speed
+                if original_speed <= 0:
+                    object.speed = 0.01
+
+                try:
+                    object.activate(putDict)
+                finally:
+                    object.speed = original_speed
+
             if "palette" in putDict:
                 object.palette = putDict["palette"]
             if "metadata" in putDict:
                 object.name = putDict["metadata"]["name"]
+                configManager.bridgeConfig.mark_dirty("scenes")
         elif resource == "smart_scene":
             if "recall" in putDict and "action" in putDict["recall"]:
                 object.activate(putDict)

--- a/BridgeEmulator/services/mqtt.py
+++ b/BridgeEmulator/services/mqtt.py
@@ -445,10 +445,12 @@ def on_message(client, userdata, msg):
                             state["on"] = True if data["state"] == "ON" else False
                             v2State.update({"on":{"on": state["on"]}})
 
-                            # External OFF may bypass set_light().
-                            # Stop the effect before another animation
-                            # frame can switch the physical light on.
+                            # External OFF may bypass Light.setV1State()
+                            # and Light.setV2State(). Stop a running
+                            # dynamic scene as well as any emulated effect.
                             if state["on"] is False:
+                                light.dynamics["status"] = "none"
+
                                 try:
                                     protocol_mqtt = (
                                         importlib.import_module(


### PR DESCRIPTION
This improves Hue V2 dynamic-scene runtime behaviour.

The changes:

- apply scene speed before recall so the requested speed is used immediately
- propagate live Hue speed changes to an already running dynamic scene
- safely handle speed 0 without division-by-zero errors
- recalculate timing when the Hue speed slider changes
- replace one long scene sleep with short waits so speed and OFF changes react quickly
- stop dynamic scenes when a light is switched off through V1 or V2
- stop dynamic scenes when Zigbee2MQTT reports an external OFF from Home Assistant or another controller

Without the OFF handling, a dynamic-scene worker can remain alive long enough to publish another transition after the light has been switched off.

Tested locally with diyHue, Zigbee2MQTT, Home Assistant and the Philips Hue app, including live dynamic-scene speed changes and external OFF behaviour.

This PR is independent of the event-stream work in #1109.
