### PR TITLE
Fix V2 scene action updates and dynamic light exclusion

### DIFF
--- a/BridgeEmulator/HueObjects/Scene.py
+++ b/BridgeEmulator/HueObjects/Scene.py
@@ -63,11 +63,31 @@ class Scene():
                 self.status = data["recall"]["action"]
                 lightIndex = 0
                 for light in self.lights:
-                    if light():
-                        light().dynamics["speed"] = self.speed
-                        Thread(target=light().dynamicScenePlay, args=[
-                            self.palette, lightIndex]).start()
-                        lightIndex += 1
+                    if not light():
+                        continue
+
+                    lightObj = light()
+                    sceneState = self.lightstates.get(lightObj)
+
+                    # GroupScene.lights contains every light in the room.
+                    # Only lights represented by the saved scene actions
+                    # should participate in dynamic playback.
+                    if sceneState is None:
+                        continue
+
+                    # Hue stores lights disabled in the scene as on:false.
+                    # Keep those lights off instead of starting a dynamic
+                    # scene worker for them.
+                    if sceneState.get("on") is False:
+                        lightObj.setV1State({"on": False})
+                        continue
+
+                    lightObj.dynamics["speed"] = self.speed
+                    Thread(
+                        target=lightObj.dynamicScenePlay,
+                        args=[self.palette, lightIndex]
+                    ).start()
+                    lightIndex += 1
                 return
             elif data["recall"]["action"] == "deactivate":
                 self.status = "inactive"

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -724,6 +724,58 @@ class ClipV2ResourceId(Resource):
                     Popen(["killall", "openssl"])
                     object.update_attr({"stream": {"active": False}})
         elif resource == "scene":
+            # Existing scenes are edited through the V2 "actions" list.
+            # Previously this was handled when creating a scene but ignored
+            # on PUT, so edits made in the Hue app did not update lightstates.
+            if "actions" in putDict:
+                lightstates = weakref.WeakKeyDictionary()
+
+                for action in putDict["actions"]:
+                    target = action.get("target", {})
+
+                    if target.get("rtype") != "light":
+                        continue
+
+                    lightObj = getObject(
+                        "light",
+                        target.get("rid")
+                    )
+
+                    if not lightObj:
+                        continue
+
+                    scene = action.get("action", {})
+                    sceneState = {}
+
+                    if "on" in scene:
+                        sceneState["on"] = scene["on"]["on"]
+
+                    if "dimming" in scene:
+                        sceneState["bri"] = int(
+                            scene["dimming"]["brightness"] * 2.54
+                        )
+
+                    if "color" in scene:
+                        if "xy" in scene["color"]:
+                            sceneState["xy"] = [
+                                scene["color"]["xy"]["x"],
+                                scene["color"]["xy"]["y"]
+                            ]
+
+                    if "color_temperature" in scene:
+                        if "mirek" in scene["color_temperature"]:
+                            sceneState["ct"] = (
+                                scene["color_temperature"]["mirek"]
+                            )
+
+                    if "gradient" in scene:
+                        sceneState["gradient"] = scene["gradient"]
+
+                    lightstates[lightObj] = sceneState
+
+                object.lightstates = lightstates
+                configManager.bridgeConfig.mark_dirty("scenes")
+
             # Hue scene speed is 0.0..1.0. Apply it BEFORE recall
             # and propagate changes to an already running dynamic scene.
             if "speed" in putDict:


### PR DESCRIPTION
## Summary

Fix editing and playback of Hue V2 scenes where individual lights are disabled or excluded.

## Problem

When an existing scene is edited in the Philips Hue app, the V2 API sends the updated per-light configuration in `actions`.

The scene PUT handler did not process `actions`, so changes to individual scene lights were ignored.

For dynamic GroupScenes there was a second issue: `dynamic_palette` iterated over every light in the room and started dynamic playback regardless of the saved scene light state.

This meant a light set to off in a dynamic scene could still participate when the scene was recalled.

## Changes

- process `actions` when updating an existing V2 scene
- rebuild `Scene.lightstates` from the supplied V2 actions
- preserve existing scene speed/recall handling
- make dynamic GroupScene playback use the saved scene lightstates
- skip lights not represented by the scene
- honour explicit `on:false` actions instead of starting dynamic playback for those lights
- use contiguous palette indices only for participating lights

## Reproduction

1. Create or select a dynamic Hue scene in a room with multiple lights.
2. Edit the scene in the Philips Hue app.
3. Set one light to off while leaving the others active.
4. Save the scene.
5. Recall it using dynamic playback.

Before this change, the disabled light could still participate.

After this change, the disabled light remains off and only the active scene lights run the dynamic palette.

## Testing

Tested with the Philips Hue app against diyHue using a three-light GroupScene:

- two lights active
- one light explicitly saved as `on:false`
- V1 API reflected the updated state
- V2 API reflected the updated state
- persisted scene configuration retained `on:false`
- state survived a diyHue restart
- dynamic playback started only for the two active lights
- existing dynamic scene speed handling remained intact

`python3 -m py_compile` and `git diff --check` also pass.
