### PR TITLE
Fix HSV to RGB value offset

### DIFF
--- a/BridgeEmulator/functions/colors.py
+++ b/BridgeEmulator/functions/colors.py
@@ -102,4 +102,4 @@ def hsv_to_rgb(h, s, v):
         g = 0
         b = x
 
-    return clampRGB([r * 255, g * 255, b * 255])
+    return clampRGB([(r + m) * 255, (g + m) * 255, (b + m) * 255])


### PR DESCRIPTION
Fixes #946.

hsv_to_rgb() calculates the HSV value offset m = v - c but previously discarded it when producing RGB values.

This caused reduced saturation to darken toward black instead of mixing toward white. For example, HSV with zero saturation and maximum brightness incorrectly returned [0, 0, 0] instead of [255, 255, 255].

The fix applies m to all three RGB channels using the standard HSV-to-RGB conversion.

Tested:
- full red -> [255, 0, 0]
- half-saturation red -> [255, 127, 127]
- zero saturation/max brightness -> [255, 255, 255]
- zero brightness -> [0, 0, 0]

python3 -m py_compile and git diff --check also pass.