### PR TITLE
Harden dynamic gradient scene point count

### DIFF
--- a/BridgeEmulator/HueObjects/Light.py
+++ b/BridgeEmulator/HueObjects/Light.py
@@ -327,7 +327,7 @@ class Light():
                 if self.modelid in ["LCX002", "915005987201", "LCX004", "LCX006"]:
                     # for gradient lights
                     gradientIndex = index
-                    for x in range(self.protocol_cfg["points_capable"]):
+                    for x in range(self.protocol_cfg.get("points_capable", 5)):
                         points.append(palette["color"][gradientIndex])
                         gradientIndex += 1
                         if gradientIndex == len(palette["color"]):


### PR DESCRIPTION
## Summary

Prevent dynamic gradient scenes from crashing when a light has no points_capable value in protocol_cfg.

Related to #1035 and #1062.

## Problem

The V2 light resource path already handles missing points_capable metadata with a fallback of 5, but dynamicScenePlay() still accessed protocol_cfg["points_capable"] directly.

That leaves a second KeyError path for gradient lights with incomplete protocol metadata.

## Change

Use the same safe fallback in dynamic gradient playback:

    self.protocol_cfg.get("points_capable", 5)

Existing lights that provide their actual point count are unchanged. The default is only used when the metadata is missing.

## Testing

- python3 -m py_compile BridgeEmulator/HueObjects/Light.py
- git diff --check
- verified no direct protocol_cfg["points_capable"] access remains
- verified configured values are preserved and missing metadata falls back to 5
