### PR TITLE
Handle empty YAML config files

### DIFF
--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -24,7 +24,7 @@ class NoAliasDumper(yaml.SafeDumper):
 
 def _open_yaml(path):
     with open(path, 'r', encoding="utf-8") as fp:
-        return yaml.load(fp, Loader=yaml.FullLoader)
+        return yaml.load(fp, Loader=yaml.FullLoader) or {}
 
 def _write_yaml(path, contents):
     with open(path, 'w', encoding="utf-8") as fp:


### PR DESCRIPTION
## Summary

Prevent diyHue from failing to start when an existing YAML resource file is empty.

Fixes #975.

## Problem

PyYAML returns None for an empty YAML document.

The config loader expects resource YAML files to contain mappings and immediately calls methods such as .items() or .keys().

An empty scenes.yaml therefore causes:

    AttributeError: 'NoneType' object has no attribute 'items'

and aborts diyHue startup.

Because _open_yaml() is shared by the resource loaders, the same underlying failure can affect other empty YAML resource files.

## Change

Normalize an empty YAML document to an empty dictionary in _open_yaml().

Normal non-empty YAML mappings remain unchanged.

## Testing

- reproduced yaml.load(empty) returning None before the fix
- verified an empty YAML file returns {} after the fix
- verified normal nested YAML still loads unchanged
- python3 -m py_compile BridgeEmulator/configManager/configHandler.py
- git diff --check
