### PR TITLE
Fix V2 scene update persistence

### DIFF
--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -774,7 +774,7 @@ class ClipV2ResourceId(Resource):
                     lightstates[lightObj] = sceneState
 
                 object.lightstates = lightstates
-                configManager.bridgeConfig.mark_dirty("scenes")
+                configManager.bridgeConfig.save_config(backup=False, resource="scenes")
 
             # Hue scene speed is 0.0..1.0. Apply it BEFORE recall
             # and propagate changes to an already running dynamic scene.
@@ -820,7 +820,7 @@ class ClipV2ResourceId(Resource):
                 object.palette = putDict["palette"]
             if "metadata" in putDict:
                 object.name = putDict["metadata"]["name"]
-                configManager.bridgeConfig.mark_dirty("scenes")
+                configManager.bridgeConfig.save_config(backup=False, resource="scenes")
         elif resource == "smart_scene":
             if "recall" in putDict and "action" in putDict["recall"]:
                 object.activate(putDict)


### PR DESCRIPTION
## Summary

Fix V2 scene updates calling a configuration dirty marker that does not exist.

## Problem

The V2 scene PUT handler contains two calls to `mark_dirty("scenes")`, but the Config class does not implement `mark_dirty()`.

This can raise `AttributeError` after an in-memory scene update has already been applied.

## Change

Replace both invalid calls with diyHue's existing resource-specific persistence mechanism:

`save_config(backup=False, resource="scenes")`

The existing V2 actions, lightstates and dynamic-scene logic remain unchanged.

## Testing

- verified no `mark_dirty("scenes")` calls remain
- verified exactly two scene-specific `save_config()` calls
- verified the V2 actions/lightstates logic remains intact
- Python syntax check passed
- `git diff --check` passed
- exactly one file changed, +2/-2
