### PR TITLE
Fix smart scene deactivation state

### DIFF
--- a/BridgeEmulator/HueObjects/SmartScene.py
+++ b/BridgeEmulator/HueObjects/SmartScene.py
@@ -44,12 +44,38 @@ class SmartScene():
         StreamEvent(streamMessage)
         logging.info(self.name + " smart_scene was destroyed.")
 
+    def _set_state(self, state):
+        if self.state == state:
+            return
+        self.state = state
+        self.lastupdated = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        streamMessage = {
+            "creationtime": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            "data": [{
+                "id": self.id_v2,
+                "type": "smart_scene",
+                "state": self.state
+            }],
+            "id": str(uuid.uuid4()),
+            "type": "update"
+        }
+        StreamEvent(streamMessage)
+        import configManager
+        configManager.bridgeConfig.save_config(
+            backup=False,
+            resource="smart_scene"
+        )
+
     def activate(self, data):
         # activate smart scene
         if "recall" in data:
             if data["recall"]["action"] == "activate":
                 logging.debug("activate smart_scene: " + self.name + " scene: " + str(self.active_timeslot))
-                self.state = "active"
+                self._set_state("active")
                 if datetime.now().strftime("%A").lower() in self.recurrence:
                     from flaskUI.v2restapi import getObject
                     target_object = getObject(self.timeslots[self.active_timeslot]["target"]["rtype"], self.timeslots[self.active_timeslot]["target"]["rid"])
@@ -57,11 +83,8 @@ class SmartScene():
                     target_object.activate(putDict)
                 return
             if data["recall"]["action"] == "deactivate":
-                from functions.scripts import findGroup
-                group = findGroup(self.group["rid"])
-                group.setV1Action(state={"on": False})
                 logging.debug("deactivate smart_scene: " + self.name)
-                self.state = "inactive"
+                self._set_state("inactive")
                 return
 
 


### PR DESCRIPTION
## Summary

Correct smart-scene activation and deactivation state handling.

Related to #1058.

## Problem

A V2 smart-scene `deactivate` currently turns the entire group off before setting the smart scene to inactive.

Hue smart-scene deactivation is intended to stop future scheduled smart-scene transitions, not turn the lights off.

The active/inactive state is also only changed in memory, so it can remain stale on disk until the periodic configuration save.

## Change

- stop turning the group off when a smart scene is deactivated
- centralize active/inactive state changes
- persist `smart_scene` immediately when the state changes
- emit a V2 smart_scene state update event

## Testing

- verified deactivate changes state from active to inactive
- verified deactivate does not require or modify a group
- verified smart_scene is saved immediately
- verified a V2 update event contains the new state
- verified activate also persists and emits its active state
- Python syntax check passed
- git diff --check passed
- only SmartScene.py is changed
