### PR TITLE
Add server-side Hue bridge pairing with HTTPS support

### DIFF
--- a/BridgeEmulator/HueEmulator3.py
+++ b/BridgeEmulator/HueEmulator3.py
@@ -8,7 +8,7 @@ import configManager
 import logManager
 import flask_login
 from flaskUI.core import User #dummy import for flaks_login module
-from flaskUI.restful import NewUser, ShortConfig, EntireConfig, ResourceElements, Element, ElementParam, ElementParamId
+from flaskUI.restful import NewUser, ShortConfig, EntireConfig, ResourceElements, Element, ElementParam, ElementParamId, HueBridgeLink
 from flaskUI.v2restapi import AuthV1, ClipV2, ClipV2Resource, ClipV2ResourceId
 from flaskUI.espDevices import Switch
 from flaskUI.Credits import Credits
@@ -64,6 +64,7 @@ api.add_resource(Switch, '/switch')
 ### HUE API
 api.add_resource(NewUser, '/api/', strict_slashes=False)
 api.add_resource(ShortConfig, '/api/config', strict_slashes=False)
+api.add_resource(HueBridgeLink, '/api/<string:username>/config/hue/link', strict_slashes=False)
 api.add_resource(EntireConfig, '/api/<string:username>', strict_slashes=False)
 api.add_resource(ResourceElements, '/api/<string:username>/<string:resource>', strict_slashes=False)
 api.add_resource(Element, '/api/<string:username>/<string:resource>/<string:resourceid>', strict_slashes=False)

--- a/BridgeEmulator/flaskUI/restful.py
+++ b/BridgeEmulator/flaskUI/restful.py
@@ -5,10 +5,12 @@ import weakref
 import uuid
 import json
 import os
+import ipaddress
 from subprocess import Popen
 from threading import Thread
 from datetime import datetime, timezone
 from lights.discover import scanForLights, manualAddLight
+from lights.protocols import hue
 from functions.core import capabilities, staticConfig, nextFreeId
 from flask_restful import Resource
 from flask import request
@@ -131,6 +133,71 @@ class NewUser(Resource):
         else:
             logging.error("parameter, " + list(postDict.keys())[0] + ", not available")
             return [{"error": {"type": 6, "address": "/api/" + list(postDict.keys())[0], "description":"parameter, " + list(postDict.keys())[0] + ", not available"}}]
+
+
+def _hue_link_error(description, error_type=901):
+    return [{
+        "error": {
+            "type": error_type,
+            "address": "/config/hue/link",
+            "description": description,
+        }
+    }]
+
+
+class HueBridgeLink(Resource):
+    def post(self, username):
+        authorisation = authorize(username, "config")
+        if "success" not in authorisation:
+            return authorisation
+
+        postDict = request.get_json(force=True)
+
+        try:
+            host = postDict["ip"].strip()
+            address = ipaddress.ip_address(host)
+
+            if (
+                address.version != 4
+                or address.is_loopback
+                or address.is_multicast
+                or address.is_unspecified
+                or not (address.is_private or address.is_link_local)
+            ):
+                raise ValueError
+        except (AttributeError, KeyError, ValueError):
+            return _hue_link_error(
+                "invalid local Hue Bridge IPv4 address",
+                7,
+            )
+
+        try:
+            result, scheme = hue.link_bridge(host)
+        except ConnectionError:
+            logging.warning("Unable to connect to Hue Bridge at %s", host)
+            return _hue_link_error("unable to connect to Hue Bridge")
+
+        if "success" not in result[0]:
+            return result
+
+        success = result[0]["success"]
+        if not success.get("username"):
+            return _hue_link_error("Hue Bridge returned no username")
+
+        bridgeConfig["config"]["hue"].update({
+            "ip": host,
+            "scheme": scheme,
+            "hueUser": success["username"],
+            "hueKey": success.get("clientkey", ""),
+        })
+
+        configManager.bridgeConfig.save_config(
+            backup=False,
+            resource="config",
+        )
+
+        success["scheme"] = scheme
+        return result
 
 
 class ShortConfig(Resource):

--- a/BridgeEmulator/lights/discover.py
+++ b/BridgeEmulator/lights/discover.py
@@ -209,6 +209,9 @@ def scanForLights():  # scan for ESP8266 lights and strips
                     if lightObj.protocol_cfg["uniqueid"] == light["protocol_cfg"]["uniqueid"]  and lightObj.modelid == light["modelid"]:
                         logging.info("Update IP for light " + light["name"])
                         lightObj.protocol_cfg["ip"] = light["protocol_cfg"]["ip"]
+                        if light["protocol"] == "hue":
+                            lightObj.protocol_cfg["hueUser"] = light["protocol_cfg"]["hueUser"]
+                            lightObj.protocol_cfg["scheme"] = light["protocol_cfg"]["scheme"]
                         lightIsNew = False
                 elif light["protocol"] in ["wled"]:
                     # Check based on mac and segment and modelid

--- a/BridgeEmulator/lights/protocols/hue.py
+++ b/BridgeEmulator/lights/protocols/hue.py
@@ -1,11 +1,54 @@
 import json
 import logManager
 import requests
+import warnings
+from urllib3.exceptions import InsecureRequestWarning
 
 logging = logManager.logger.get_logger(__name__)
 
+
+def _request(method, config, path, **kwargs):
+    scheme = config.get("scheme", "http")
+    url = scheme + "://" + config["ip"] + path
+    kwargs.setdefault("timeout", 3)
+
+    if scheme == "https":
+        kwargs["verify"] = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", InsecureRequestWarning)
+            return requests.request(method, url, **kwargs)
+
+    return requests.request(method, url, **kwargs)
+
+
+def link_bridge(ip):
+    payload = {
+        "devicetype": "diyhue#bridge",
+        "generateclientkey": True,
+    }
+    last_error = None
+
+    for scheme in ("https", "http"):
+        try:
+            response = _request(
+                "post",
+                {"ip": ip, "scheme": scheme},
+                "/api",
+                json=payload,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if isinstance(result, list) and result:
+                    return result, scheme
+        except (requests.RequestException, ValueError, TypeError) as error:
+            last_error = error
+
+    raise ConnectionError("Unable to connect to Hue Bridge") from last_error
+
+
 def set_light(light, data):
-    url = "http://" + light.protocol_cfg["ip"] + "/api/" + light.protocol_cfg["hueUser"] + "/lights/" + light.protocol_cfg["id"] + "/state"
+    path = "/api/" + light.protocol_cfg["hueUser"] + "/lights/" + light.protocol_cfg["id"] + "/state"
     payload = {}
     payload.update(data)
     color = {}
@@ -22,19 +65,29 @@ def set_light(light, data):
         color["sat"] = payload["sat"]
         del(payload["sat"])
     if len(payload) != 0:
-        requests.put(url, json=payload, timeout=3)
+        _request("put", light.protocol_cfg, path, json=payload)
     if len(color) != 0:
-        requests.put(url, json=color, timeout=3)
+        _request("put", light.protocol_cfg, path, json=color)
+
 
 def get_light_state(light):
-    state = requests.get("http://" + light.protocol_cfg["ip"] + "/api/" + light.protocol_cfg["hueUser"] + "/lights/" + light.protocol_cfg["id"], timeout=3)
-    return state.json()["state"]
+    response = _request(
+        "get",
+        light.protocol_cfg,
+        "/api/" + light.protocol_cfg["hueUser"] + "/lights/" + light.protocol_cfg["id"],
+    )
+    return response.json()["state"]
+
 
 def discover(detectedLights, credentials):
     if "hueUser" in credentials and len(credentials["hueUser"]) > 32:
         logging.debug("hue: <discover> invoked!")
         try:
-            response = requests.get("http://" + credentials["ip"] + "/api/" + credentials["hueUser"] + "/lights", timeout=3)
+            response = _request(
+                "get",
+                credentials,
+                "/api/" + credentials["hueUser"] + "/lights",
+            )
             if response.status_code == 200:
                 logging.debug(response.text)
                 lights = json.loads(response.text)
@@ -48,6 +101,18 @@ def discover(detectedLights, credentials):
                         modelid = "LOM001"
                     elif light["type"] == "Color light":
                         modelid = "LLC010"
-                    detectedLights.append({"protocol": "hue", "name": light["name"], "modelid": modelid, "protocol_cfg": {"ip": credentials["ip"], "hueUser": credentials["hueUser"], "modelid": light["modelid"], "id": id, "uniqueid": light["uniqueid"]}})
+                    detectedLights.append({
+                        "protocol": "hue",
+                        "name": light["name"],
+                        "modelid": modelid,
+                        "protocol_cfg": {
+                            "ip": credentials["ip"],
+                            "scheme": credentials.get("scheme", "http"),
+                            "hueUser": credentials["hueUser"],
+                            "modelid": light["modelid"],
+                            "id": id,
+                            "uniqueid": light["uniqueid"],
+                        }
+                    })
         except Exception as e:
             logging.info("Error connecting to Hue Bridge: %s", e)


### PR DESCRIPTION
## Summary

Adds server-side pairing and HTTPS transport support for external Philips Hue bridges.

The current WebUI pairs by sending a browser-side HTTP request directly to the physical Hue bridge. This fails for the Hue Bridge Pro because the browser either blocks the HTTP request as mixed content or hits CORS/redirect restrictions.

This change moves the bridge-side pairing request into diyHue and adds HTTPS support to the existing Hue protocol implementation.

## Changes

- Add `POST /api/<username>/config/hue/link` for server-side Hue bridge pairing.
- Try HTTPS first when pairing, with HTTP fallback for older bridges.
- Use the selected transport for Hue discovery, state reads, and light control.
- Persist `scheme`, `hueUser`, and `hueKey` in the Hue bridge config.
- Refresh Hue credentials and transport for already imported lights during rediscovery.
- Keep legacy configurations without a `scheme` field on HTTP.
- Restrict the pairing proxy to local IPv4 addresses.
- Suppress `InsecureRequestWarning` only around Hue HTTPS requests using the bridge-local certificate.

## Backward compatibility

Existing Hue configurations do not contain a `scheme` field. They continue to default to HTTP, preserving the previous behavior.

New pairings prefer HTTPS and only fall back to HTTP when HTTPS cannot be used.

## Testing

Tested against an isolated HTTPS-only Hue Bridge Pro simulator with a self-signed certificate using the normal diyHue runtime and API paths.

Verified end-to-end:

- server-side pairing over HTTPS
- username and client key persistence
- normal `scanForLights()` discovery
- import of a Hue light through the existing Hue protocol
- preservation of the remote Hue `uniqueid` in `protocol_cfg`
- persistence of `scheme=https` on imported lights
- actual diyHue V1 light-state PUT reaching the simulated bridge over HTTPS
- `on=true` and `bri=123` received by the simulated bridge
- HTTP fallback for legacy bridges
- legacy configs without `scheme` continue to use HTTP
- Hue API error responses such as link-button error 101 do not incorrectly trigger HTTP fallback
- no `InsecureRequestWarning` spam during HTTPS operation

The UI production build was also tested with the corresponding WebUI change that calls this new backend endpoint instead of contacting the physical bridge directly.

## Hardware validation

This has **not yet been tested against a physical Hue Bridge Pro**. The end-to-end test used an HTTPS-only simulator reproducing the relevant local Hue API behavior and self-signed TLS setup.

A physical Bridge Pro test would therefore still be useful before considering Bridge Pro support fully validated.

## Related issues

Part of the fix for #1091. Companion UI PR: diyhue/diyHueUI#25, which removes the browser-side HTTP pairing request.

Related to #1092, specifically the ability for diyHue to connect to and control resources through a Hue Bridge Pro. This does not make diyHue emulate a Bridge Pro and does not add WLED devices to the physical Hue bridge.

