### PR TITLE
Add canonical MotionAware configuration validation

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -36,6 +36,7 @@ COPY ./BridgeEmulator/HueObjects/ /opt/hue-emulator/HueObjects/
 COPY ./BridgeEmulator/services/ /opt/hue-emulator/services/
 COPY ./BridgeEmulator/configManager/ /opt/hue-emulator/configManager/
 COPY ./BridgeEmulator/logManager/ /opt/hue-emulator/logManager/
+COPY ./BridgeEmulator/motionAwareConfig.py /opt/hue-emulator/
 COPY ./BridgeEmulator/HueEmulator3.py /opt/hue-emulator/
 COPY ./BridgeEmulator/githubInstall.sh /opt/hue-emulator/
 

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -1,4 +1,5 @@
 from configManager import configInit
+from motionAwareConfig import normalize_motion_aware_config
 from configManager.argumentHandler import parse_arguments, generate_certificate
 import os
 import pathlib
@@ -129,6 +130,12 @@ class Config:
                     config["swversion"] = "1975104000"
                 if float(config["apiversion"][:3]) < 1.75:
                     config["apiversion"] = "1.75.0"
+
+                # Normalize legacy MotionAware persistence without treating
+                # config presence as a capability or enabling the feature.
+                _, motion_aware_issues = normalize_motion_aware_config(config)
+                for issue in motion_aware_issues:
+                    logging.warning("MotionAware config migration: %s", issue)
 
                 self.yaml_config["config"] = config
             else:

--- a/BridgeEmulator/motionAwareConfig.py
+++ b/BridgeEmulator/motionAwareConfig.py
@@ -1,0 +1,193 @@
+"""Canonical MotionAware configuration keys and safe readers.
+
+The persisted representation intentionally lives below ``config.motion_aware``.
+Live RF/motion state is not part of this schema and must never be written here.
+This module has no dependency on the runtime object graph, which makes it safe
+to use while config.yaml is being loaded and migrated.
+"""
+
+MOTION_AWARE_KEY = "motion_aware"
+LEGACY_MOTION_AWARE_KEYS = ("motionAware", "motionaware")
+AREAS_KEY = "areas"
+
+MOTION_AREA_CONFIGURATION = "motion_area_configuration"
+CONVENIENCE_AREA_MOTION = "convenience_area_motion"
+SECURITY_AREA_MOTION = "security_area_motion"
+MOTION_AREA_CANDIDATE = "motion_area_candidate"
+
+MOTION_SERVICE_TYPES = (
+    CONVENIENCE_AREA_MOTION,
+    SECURITY_AREA_MOTION,
+)
+SERVED_MOTION_RESOURCE_TYPES = (
+    MOTION_AREA_CONFIGURATION,
+    *MOTION_SERVICE_TYPES,
+)
+
+DEFAULT_AREA_ENABLED = True
+DEFAULT_SERVICE_ENABLED = True
+DEFAULT_SENSITIVITY = 2
+MAX_SENSITIVITY = 4
+DEFAULT_HEALTH = "healthy"
+VALID_HEALTH = ("healthy", "unhealthy")
+VALID_GROUP_TYPES = ("bridge_home", "room", "zone")
+
+
+def normalize_motion_aware_config(config):
+    """Normalize only the MotionAware container and return ``(changed, issues)``.
+
+    A missing key remains missing. This is important: config presence is not a
+    capability flag. MotionAware availability is derived separately from the
+    bridge profile. Unknown fields are retained for forward compatibility.
+    Malformed container values are replaced with an empty, inert area map.
+    """
+    if not isinstance(config, dict):
+        raise TypeError("bridge config must be a dictionary")
+
+    changed = False
+    issues = []
+
+    # Older experimental builds used camel-case container names.  Migrate
+    # them once into the canonical diyHue key instead of silently stranding
+    # persisted areas or reading two competing sources of truth.
+    legacy_values = [
+        config[key]
+        for key in LEGACY_MOTION_AWARE_KEYS
+        if key in config
+    ]
+    if MOTION_AWARE_KEY not in config and legacy_values:
+        config[MOTION_AWARE_KEY] = legacy_values[0]
+        changed = True
+    for key in LEGACY_MOTION_AWARE_KEYS:
+        if key in config:
+            del config[key]
+            changed = True
+            if len(legacy_values) > 1:
+                issues.append("multiple legacy MotionAware keys; first value retained")
+
+    if MOTION_AWARE_KEY not in config:
+        return changed, issues
+
+    motion_aware = config.get(MOTION_AWARE_KEY)
+
+    if not isinstance(motion_aware, dict):
+        config[MOTION_AWARE_KEY] = {AREAS_KEY: {}}
+        return True, ["motion_aware must be an object; reset to an empty area map"]
+
+    if AREAS_KEY not in motion_aware:
+        motion_aware[AREAS_KEY] = {}
+        changed = True
+    elif not isinstance(motion_aware[AREAS_KEY], dict):
+        motion_aware[AREAS_KEY] = {}
+        changed = True
+        issues.append("motion_aware.areas must be an object; reset to empty")
+
+    return changed, issues
+
+
+def get_motion_aware_areas(config, create=False):
+    """Return the canonical area map without leaking malformed containers."""
+    if not isinstance(config, dict):
+        return {}
+
+    motion_aware = config.get(MOTION_AWARE_KEY)
+    if not isinstance(motion_aware, dict):
+        if not create:
+            return {}
+        motion_aware = {}
+        config[MOTION_AWARE_KEY] = motion_aware
+
+    areas = motion_aware.get(AREAS_KEY)
+    if not isinstance(areas, dict):
+        if not create:
+            return {}
+        areas = {}
+        motion_aware[AREAS_KEY] = areas
+
+    return areas
+
+
+def get_stored_area(config, area_id):
+    """Return one valid stored area object or an empty read-only fallback."""
+    area = get_motion_aware_areas(config).get(area_id)
+    return area if isinstance(area, dict) else {}
+
+
+def read_bool(mapping, key, default):
+    """Read a real JSON boolean, preserving ``False`` and rejecting 0/1."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if isinstance(value, bool) else default
+
+
+def read_int(mapping, key, default, minimum=None, maximum=None):
+    """Read an integer without accepting bool (a Python int subclass)."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    if minimum is not None and value < minimum:
+        return default
+    if maximum is not None and value > maximum:
+        return default
+    return value
+
+
+def read_nonempty_string(mapping, key, default):
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if isinstance(value, str) and value.strip() else default
+
+
+def read_health(mapping, key="health", default=DEFAULT_HEALTH):
+    """Read the two health enum values understood by Hue's MotionArea model."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if value in VALID_HEALTH else default
+
+
+def read_resource_reference(value, allowed_types):
+    """Return a normalized V2 resource reference or ``None``."""
+    if not isinstance(value, dict):
+        return None
+    rid = value.get("rid")
+    rtype = value.get("rtype")
+    if not isinstance(rid, str) or not rid or rtype not in allowed_types:
+        return None
+    return {"rid": rid, "rtype": rtype}
+
+
+def read_participants(value):
+    """Return canonical participant records, or ``None`` if malformed.
+
+    Participant health is server-owned runtime metadata. Persisted legacy
+    health is accepted only when it is a non-empty string; otherwise the
+    canonical default is used.
+    """
+    if not isinstance(value, list):
+        return None
+
+    result = []
+    seen = set()
+    for participant in value:
+        if not isinstance(participant, dict):
+            return None
+        resource = read_resource_reference(
+            participant.get("resource"),
+            (MOTION_AREA_CANDIDATE,),
+        )
+        if resource is None or resource["rid"] in seen:
+            return None
+        seen.add(resource["rid"])
+        status = participant.get("status")
+        health = read_health(status)
+        result.append({
+            "resource": resource,
+            "status": {"health": health},
+        })
+
+    return result

--- a/tests/test_motion_aware_config.py
+++ b/tests/test_motion_aware_config.py
@@ -1,0 +1,123 @@
+import copy
+import pathlib
+import sys
+import unittest
+
+
+BRIDGE_EMULATOR = pathlib.Path(__file__).parents[1] / "BridgeEmulator"
+sys.path.insert(0, str(BRIDGE_EMULATOR))
+
+from motionAwareConfig import (  # noqa: E402
+    get_motion_aware_areas,
+    normalize_motion_aware_config,
+    read_bool,
+    read_int,
+    read_health,
+    read_participants,
+    read_resource_reference,
+)
+
+
+class MotionAwareConfigTests(unittest.TestCase):
+    def test_missing_config_does_not_enable_or_mutate_feature(self):
+        config = {"bridge_profile": "classic"}
+        before = copy.deepcopy(config)
+        self.assertEqual(normalize_motion_aware_config(config), (False, []))
+        self.assertEqual(config, before)
+        self.assertEqual(get_motion_aware_areas(config), {})
+
+    def test_malformed_containers_become_inert_and_idempotent(self):
+        for malformed in (None, False, 0, "enabled", []):
+            with self.subTest(malformed=malformed):
+                config = {"motion_aware": malformed}
+                changed, issues = normalize_motion_aware_config(config)
+                self.assertTrue(changed)
+                self.assertTrue(issues)
+                self.assertEqual(config["motion_aware"], {"areas": {}})
+                self.assertEqual(
+                    normalize_motion_aware_config(config),
+                    (False, []),
+                )
+
+    def test_missing_areas_is_added_without_losing_unknown_fields(self):
+        config = {"motion_aware": {"future_field": {"x": 1}}}
+        self.assertEqual(normalize_motion_aware_config(config), (True, []))
+        self.assertEqual(config["motion_aware"]["areas"], {})
+        self.assertEqual(config["motion_aware"]["future_field"], {"x": 1})
+
+    def test_legacy_container_is_migrated_to_canonical_key(self):
+        config = {"motionAware": {"areas": {"old": {}}}}
+        changed, issues = normalize_motion_aware_config(config)
+        self.assertTrue(changed)
+        self.assertEqual(issues, [])
+        self.assertNotIn("motionAware", config)
+        areas = get_motion_aware_areas(config, create=True)
+        areas["new"] = {"enabled": False}
+        self.assertEqual(
+            config["motion_aware"],
+            {"areas": {"old": {}, "new": {"enabled": False}}},
+        )
+
+    def test_boolean_reader_preserves_false_and_rejects_ints(self):
+        self.assertFalse(read_bool({"enabled": False}, "enabled", True))
+        self.assertTrue(read_bool({}, "enabled", True))
+        self.assertTrue(read_bool({"enabled": None}, "enabled", True))
+        self.assertTrue(read_bool({"enabled": 0}, "enabled", True))
+
+    def test_integer_reader_preserves_zero_and_rejects_bool(self):
+        self.assertEqual(read_int({"value": 0}, "value", 2, 0, 4), 0)
+        self.assertEqual(read_int({"value": False}, "value", 2, 0, 4), 2)
+        self.assertEqual(read_int({"value": 5}, "value", 2, 0, 4), 2)
+        self.assertEqual(read_int({"value": None}, "value", 2, 0, 4), 2)
+
+    def test_resource_reference_validation(self):
+        self.assertEqual(
+            read_resource_reference(
+                {"rid": "abc", "rtype": "room"}, ("room",)
+            ),
+            {"rid": "abc", "rtype": "room"},
+        )
+        for malformed in (
+            None,
+            {},
+            {"rid": "", "rtype": "room"},
+            {"rid": "abc", "rtype": "device"},
+        ):
+            self.assertIsNone(read_resource_reference(malformed, ("room",)))
+
+    def test_participant_validation_is_canonical_and_non_mutating(self):
+        source = [{
+            "resource": {"rid": "candidate-1", "rtype": "motion_area_candidate"},
+            "status": {"health": "unhealthy"},
+            "unknown": "ignored in API mapping",
+        }]
+        before = copy.deepcopy(source)
+        self.assertEqual(
+            read_participants(source),
+            [{
+                "resource": {
+                    "rid": "candidate-1",
+                    "rtype": "motion_area_candidate",
+                },
+                    "status": {"health": "unhealthy"},
+            }],
+        )
+        self.assertEqual(source, before)
+
+    def test_health_accepts_only_hue_enum(self):
+        self.assertEqual(read_health({"health": "healthy"}), "healthy")
+        self.assertEqual(read_health({"health": "unhealthy"}), "unhealthy")
+        self.assertEqual(read_health({"health": "degraded"}), "healthy")
+        self.assertEqual(read_health({"health": None}), "healthy")
+
+    def test_participant_validation_rejects_duplicates_and_malformed(self):
+        participant = {
+            "resource": {"rid": "same", "rtype": "motion_area_candidate"}
+        }
+        self.assertIsNone(read_participants([participant, participant]))
+        self.assertIsNone(read_participants([{"resource": None}]))
+        self.assertIsNone(read_participants(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a dependency-free, canonical MotionAware configuration layer with safe readers and legacy-key migration.

## Scope

- canonical `motion_aware.areas` persistence container
- explicit migration from `motionAware` / `motionaware`
- preserves valid `False`, `0`, and empty values
- validates health, resource references, and participants
- malformed data becomes inert without crashing
- packages the new module in the Docker image

## Safety

No bridge identity, networking, certificates, production config, or Pro-specific personal data is included.

## Validation

- `python3 -m unittest -v tests.test_motion_aware_config` — 10 passed
- Python syntax check for the new module and config loader
- local Docker image build succeeded
- import inside the built image: `motionAwareConfig` and `configHandler` succeeded
- `git diff --check upstream/dev...HEAD`

The first CI run exposed a missing Dockerfile `COPY`; the follow-up commit fixes that packaging defect before merge.