### PR TITLE
Add explicit bridge profile identity abstraction

### DIFF
--- a/BridgeEmulator/configManager/argumentHandler.py
+++ b/BridgeEmulator/configManager/argumentHandler.py
@@ -35,7 +35,8 @@ def process_arguments(configDir, args):
 
 def parse_arguments():
     argumentDict = {"BIND_IP": '', "HOST_IP": '', "HTTP_PORT": '', "HTTPS_PORT": '', "FULLMAC": '', "MAC": '', "DEBUG": False, "DOCKER": False,
-                    "noLinkButton": False, "noServeHttps": False}
+                    "noLinkButton": False, "noServeHttps": False,
+                    "BRIDGE_PROFILE": None}
     ap = argparse.ArgumentParser()
 
     # Arguements can also be passed as Environment Variables.
@@ -47,6 +48,8 @@ def parse_arguments():
     ap.add_argument("--http-port", help="The port to listen on for HTTP (Docker)", type=int)
     ap.add_argument("--https-port", help="The port to listen on for HTTPS (Docker)", type=int)
     ap.add_argument("--mac", help="The MAC address of the host system (Docker)", type=str)
+    ap.add_argument("--bridge-profile", choices=("classic", "pro"),
+                    help="Bridge capability profile (classic or pro)")
     ap.add_argument("--no-serve-https", action='store_true', help="Don't listen on port 443 with SSL")
     ap.add_argument("--ip-range", help="Deprecated use webui, Set IP range for light discovery. Format: <START_IP>,<STOP_IP>", type=str)
     ap.add_argument("--sub-ip-range", help="Deprecated use webui, Set SUB IP range for light discovery. Format: <START_IP>,<STOP_IP>", type=str)
@@ -67,6 +70,17 @@ def parse_arguments():
 
     if args.no_serve_https:
         argumentDict["noServeHttps"] = True
+
+    bridge_profile = args.bridge_profile or get_environment_variable(
+        "BRIDGE_PROFILE"
+    )
+    if bridge_profile:
+        bridge_profile = bridge_profile.strip().lower()
+        if bridge_profile not in ("classic", "pro"):
+            raise SystemExit(
+                "BRIDGE_PROFILE must be either 'classic' or 'pro'"
+            )
+        argumentDict["BRIDGE_PROFILE"] = bridge_profile
 
     if args.debug or get_environment_variable('DEBUG', True):
         argumentDict["DEBUG"] = True

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -69,6 +69,8 @@ class Config:
                         "SUB_IP_RANGE_END": int(self.argsDict["HOST_IP"].split('.')[2])}
                 if "scanonhostip" not in config:
                     config["scanonhostip"] = False
+                if config.get("bridge_profile") not in ("classic", "pro"):
+                    config["bridge_profile"] = "classic"
                 if "homeassistant" not in config:
                     config["homeassistant"] = {"enabled": False}
                 if "yeelight" not in config:
@@ -144,6 +146,7 @@ class Config:
                     "Hue Essentials key": str(uuid.uuid1()).replace('-', ''),
                     "discovery": True,
                     "scanonhostip": False,
+                    "bridge_profile": "classic",
                     "mqtt":{"enabled":False},
                     "deconz":{"enabled":False},
                     "alarm":{"enabled": False,"lasttriggered": 0},

--- a/BridgeEmulator/configManager/configInit.py
+++ b/BridgeEmulator/configManager/configInit.py
@@ -18,6 +18,11 @@ def write_args(args, yaml_config):
     yaml_config["config"]["gateway"] = ip_pieces[0] + "." + ip_pieces[1] + "." + ip_pieces[2] + "." + ip_pieces[3].replace("\n", "")#".1"
     yaml_config["config"]["mac"] = args["FULLMAC"]
     yaml_config["config"]["bridgeid"] = (args["MAC"][:6] + 'FFFE' + args["MAC"][-6:]).upper()
+    # Command-line/environment selection is applied to the active bridge
+    # configuration. The regular config manager persists it on its normal
+    # save path, so a selected profile remains explicit across restarts.
+    if args.get("BRIDGE_PROFILE") is not None:
+        yaml_config["config"]["bridge_profile"] = args["BRIDGE_PROFILE"]
     return yaml_config
 
 def generate_security_key(yaml_config):

--- a/BridgeEmulator/flaskUI/restful.py
+++ b/BridgeEmulator/flaskUI/restful.py
@@ -11,7 +11,13 @@ from threading import Thread
 from datetime import datetime, timezone
 from lights.discover import scanForLights, manualAddLight
 from lights.protocols import hue
-from functions.core import capabilities, staticConfig, nextFreeId
+from functions.core import (
+    bridgeReportedApiversion,
+    bridgeReportedSwversion,
+    capabilities,
+    staticConfig,
+    nextFreeId,
+)
 from flask_restful import Resource
 from flask import request
 from functions.rules import rulesProcessor
@@ -55,19 +61,19 @@ def authorize(username, resource='', resourceId='', resourceParam=''):
 
 
 def buildConfig():
-    result = staticConfig()
     config = bridgeConfig["config"]
+    result = staticConfig(config)
     # Update with config values (excluding some diyHue-specific fields, but keeping Hue Essentials key)
     result.update({
         "Hue Essentials key": config["Hue Essentials key"],
-        "apiversion": config["apiversion"],
+        "apiversion": bridgeReportedApiversion(config),
         "bridgeid": config["bridgeid"],
         "ipaddress": config["ipaddress"],
         "netmask": config["netmask"],
         "gateway": config["gateway"],
         "mac": config["mac"],
         "name": config["name"],
-        "swversion": config["swversion"],
+        "swversion": bridgeReportedSwversion(config),
         "timezone": config["timezone"]
     })
     # Reconstruct swupdate2 in exact order to match original bridge
@@ -203,17 +209,18 @@ class HueBridgeLink(Resource):
 class ShortConfig(Resource):
     def get(self):
         config = bridgeConfig["config"]
+        identity = staticConfig(config)
         return {
-            "apiversion": config["apiversion"],
+            "apiversion": bridgeReportedApiversion(config),
             "bridgeid": config["bridgeid"],
-            "datastoreversion": staticConfig()["datastoreversion"],
+            "datastoreversion": identity["datastoreversion"],
             "factorynew": False,
             "mac": config["mac"],
-            "modelid": "BSB002",
+            "modelid": identity["modelid"],
             "name": config["name"],
             "replacesbridgeid": None,
             "starterkitid": "",
-            "swversion": config["swversion"]
+            "swversion": bridgeReportedSwversion(config)
         }
 
 
@@ -250,7 +257,8 @@ class ResourceElements(Resource):
         elif resource == "config":
             config = bridgeConfig["config"]
 
-            return {"name": config["name"], "datastoreversion": staticConfig()["datastoreversion"], "swversion": config["swversion"], "apiversion": config["apiversion"], "mac": config["mac"], "bridgeid": config["bridgeid"], "factorynew": False, "replacesbridgeid": None, "modelid": staticConfig()["modelid"], "starterkitid": ""}
+            identity = staticConfig(config)
+            return {"name": config["name"], "datastoreversion": identity["datastoreversion"], "swversion": bridgeReportedSwversion(config), "apiversion": bridgeReportedApiversion(config), "mac": config["mac"], "bridgeid": config["bridgeid"], "factorynew": False, "replacesbridgeid": None, "modelid": identity["modelid"], "starterkitid": ""}
         return [{"error": {"type": 1, "address": "/", "description": "unauthorized user"}}]
 
     def post(self, username, resource):

--- a/BridgeEmulator/functions/core.py
+++ b/BridgeEmulator/functions/core.py
@@ -1,5 +1,41 @@
 from datetime import datetime, timezone
 
+
+def bridgeIdentity(config=None):
+    if config and config.get("bridge_profile") == "pro":
+        return {
+            "profile": "pro",
+            "modelid": "BSB003",
+            "archetype": "bridge_v3",
+            "product_name": "Hue Bridge",
+            "swversion": "2071442000",
+            "apiversion": "1.78.0",
+            "software_version": "1.78.2071442000"
+        }
+
+    return {
+        "profile": "classic",
+        "modelid": "BSB002",
+        "archetype": "bridge_v2",
+        "product_name": "Philips hue",
+        "swversion": None,
+        "apiversion": None,
+        "software_version": None
+    }
+
+
+def bridgeReportedSwversion(config):
+    """Return the externally reported firmware for the active profile."""
+    identity = bridgeIdentity(config)
+    return identity["swversion"] or config["swversion"]
+
+
+def bridgeReportedApiversion(config):
+    """Return the externally reported API version for the active profile."""
+    identity = bridgeIdentity(config)
+    return identity["apiversion"] or config["apiversion"]
+
+
 def nextFreeId(bridgeConfig, element):
     i = 1
     while (str(i)) in bridgeConfig[element]:
@@ -7,7 +43,8 @@ def nextFreeId(bridgeConfig, element):
     return str(i)
 
 
-def staticConfig():
+def staticConfig(config=None):
+    identity = bridgeIdentity(config)
     return {
         "backup": {
             "errorcode": 0,
@@ -23,7 +60,7 @@ def staticConfig():
             "time": "disconnected"
         },
         "linkbutton": False,
-        "modelid": "BSB002",
+        "modelid": identity["modelid"],
         "portalconnection": "disconnected",
         "portalservices": False,
         "analyticsconsent": False,

--- a/tests/test_bridge_profile.py
+++ b/tests/test_bridge_profile.py
@@ -1,0 +1,66 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+BRIDGE_EMULATOR = pathlib.Path(__file__).parents[1] / "BridgeEmulator"
+sys.path.insert(0, str(BRIDGE_EMULATOR))
+
+from functions.core import (  # noqa: E402
+    bridgeIdentity,
+    bridgeReportedApiversion,
+    bridgeReportedSwversion,
+    staticConfig,
+)
+
+CONFIG_INIT_SPEC = importlib.util.spec_from_file_location(
+    "motionaware_test_config_init",
+    BRIDGE_EMULATOR / "configManager" / "configInit.py",
+)
+configInit = importlib.util.module_from_spec(CONFIG_INIT_SPEC)
+CONFIG_INIT_SPEC.loader.exec_module(configInit)
+
+
+class BridgeProfileTests(unittest.TestCase):
+    def test_default_profile_remains_classic(self):
+        identity = bridgeIdentity({})
+        self.assertEqual(identity["profile"], "classic")
+        self.assertEqual(identity["modelid"], "BSB002")
+        self.assertIsNone(identity["apiversion"])
+        self.assertEqual(staticConfig({})["modelid"], "BSB002")
+
+    def test_pro_profile_is_explicit_and_data_driven(self):
+        config = {"bridge_profile": "pro", "apiversion": "1.75.0", "swversion": "1975104000"}
+        identity = bridgeIdentity(config)
+        self.assertEqual(identity["profile"], "pro")
+        self.assertEqual(identity["modelid"], "BSB003")
+        self.assertEqual(bridgeReportedApiversion(config), "1.78.0")
+        self.assertEqual(bridgeReportedSwversion(config), "2071442000")
+        self.assertEqual(staticConfig(config)["modelid"], "BSB003")
+
+    def test_runtime_profile_selection_is_explicit(self):
+        config = {"config": {"bridge_profile": "classic"}}
+        args = {
+            "HOST_IP": "192.168.1.10",
+            "FULLMAC": "02:00:00:00:00:01",
+            "MAC": "020000000001",
+            "BRIDGE_PROFILE": "pro",
+        }
+        updated = configInit.write_args(args, config)
+        self.assertEqual(updated["config"]["bridge_profile"], "pro")
+
+    def test_no_runtime_override_preserves_saved_profile(self):
+        config = {"config": {"bridge_profile": "pro"}}
+        args = {
+            "HOST_IP": "192.168.1.10",
+            "FULLMAC": "02:00:00:00:00:01",
+            "MAC": "020000000001",
+            "BRIDGE_PROFILE": None,
+        }
+        updated = configInit.write_args(args, config)
+        self.assertEqual(updated["config"]["bridge_profile"], "pro")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an explicit bridge capability profile with a compatibility-preserving
`classic` default and an opt-in `pro` profile. The profile is applied
consistently to the V1 configuration identity reported by the bridge.

## Scope

- adds `--bridge-profile classic|pro` and `BRIDGE_PROFILE`
- persists a canonical `bridge_profile` value for new and existing configs
- applies environment/CLI selection to the active configuration, which the
  ordinary diyHue save path subsequently persists
- uses the selected profile for model, API-version, and software-version fields
  in V1 config responses

This intentionally does **not** add MotionAware resources, alter certificates,
or change onboarding/discovery behaviour.

## Compatibility

Missing or invalid persisted values normalize to `classic`; existing installs
retain their current BSB002 identity unless `pro` is explicitly selected.

## Validation

- `python3 -m unittest -v tests.test_bridge_profile` (4 tests)
- `python3 -m py_compile` for changed Python modules
- `git diff --check upstream/dev...HEAD`
- isolated Docker image test with `BRIDGE_PROFILE=pro`, asserting BSB003 and
  its reported V1 API/software versions