### PR TITLE
Dispatch MotionAware behavior instances through the engine

### DIFF
--- a/BridgeEmulator/HueObjects/BehaviorInstance.py
+++ b/BridgeEmulator/HueObjects/BehaviorInstance.py
@@ -48,7 +48,14 @@ class BehaviorInstance():
         if self.name != None:
             result["metadata"]["name"] = self.name
 
-        for resource in self.configuration["where"]:
+        # MotionAware behavior configurations nest `where` under the
+        # `motion` block (the stock Hue app format).  Older diyHue data may
+        # still use a top-level `where`, so support both layouts.
+        where = self.configuration.get("where", [])
+        if not where and isinstance(self.configuration.get("motion"), dict):
+            where = self.configuration["motion"].get("where", [])
+
+        for resource in where:
             result["dependees"].append({"level": "critical",
                                         "target": {
                                             "rid": resource[list(resource.keys())[0]]["rid"],

--- a/BridgeEmulator/configManager/argumentHandler.py
+++ b/BridgeEmulator/configManager/argumentHandler.py
@@ -35,7 +35,8 @@ def process_arguments(configDir, args):
 
 def parse_arguments():
     argumentDict = {"BIND_IP": '', "HOST_IP": '', "HTTP_PORT": '', "HTTPS_PORT": '', "FULLMAC": '', "MAC": '', "DEBUG": False, "DOCKER": False,
-                    "noLinkButton": False, "noServeHttps": False}
+                    "noLinkButton": False, "noServeHttps": False,
+                    "BRIDGE_PROFILE": None}
     ap = argparse.ArgumentParser()
 
     # Arguements can also be passed as Environment Variables.
@@ -47,6 +48,8 @@ def parse_arguments():
     ap.add_argument("--http-port", help="The port to listen on for HTTP (Docker)", type=int)
     ap.add_argument("--https-port", help="The port to listen on for HTTPS (Docker)", type=int)
     ap.add_argument("--mac", help="The MAC address of the host system (Docker)", type=str)
+    ap.add_argument("--bridge-profile", choices=("classic", "pro"),
+                    help="Bridge capability profile (classic or pro)")
     ap.add_argument("--no-serve-https", action='store_true', help="Don't listen on port 443 with SSL")
     ap.add_argument("--ip-range", help="Deprecated use webui, Set IP range for light discovery. Format: <START_IP>,<STOP_IP>", type=str)
     ap.add_argument("--sub-ip-range", help="Deprecated use webui, Set SUB IP range for light discovery. Format: <START_IP>,<STOP_IP>", type=str)
@@ -67,6 +70,17 @@ def parse_arguments():
 
     if args.no_serve_https:
         argumentDict["noServeHttps"] = True
+
+    bridge_profile = args.bridge_profile or get_environment_variable(
+        "BRIDGE_PROFILE"
+    )
+    if bridge_profile:
+        bridge_profile = bridge_profile.strip().lower()
+        if bridge_profile not in ("classic", "pro"):
+            raise SystemExit(
+                "BRIDGE_PROFILE must be either 'classic' or 'pro'"
+            )
+        argumentDict["BRIDGE_PROFILE"] = bridge_profile
 
     if args.debug or get_environment_variable('DEBUG', True):
         argumentDict["DEBUG"] = True

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -69,6 +69,8 @@ class Config:
                         "SUB_IP_RANGE_END": int(self.argsDict["HOST_IP"].split('.')[2])}
                 if "scanonhostip" not in config:
                     config["scanonhostip"] = False
+                if "bridge_profile" not in config:
+                    config["bridge_profile"] = "classic"
                 if "homeassistant" not in config:
                     config["homeassistant"] = {"enabled": False}
                 if "yeelight" not in config:
@@ -144,6 +146,7 @@ class Config:
                     "Hue Essentials key": str(uuid.uuid1()).replace('-', ''),
                     "discovery": True,
                     "scanonhostip": False,
+                    "bridge_profile": "classic",
                     "mqtt":{"enabled":False},
                     "deconz":{"enabled":False},
                     "alarm":{"enabled": False,"lasttriggered": 0},

--- a/BridgeEmulator/configManager/configHandler.py
+++ b/BridgeEmulator/configManager/configHandler.py
@@ -1,4 +1,5 @@
 from configManager import configInit
+from motionAwareConfig import normalize_motion_aware_config
 from configManager.argumentHandler import parse_arguments, generate_certificate
 import os
 import pathlib
@@ -129,6 +130,12 @@ class Config:
                     config["swversion"] = "1975104000"
                 if float(config["apiversion"][:3]) < 1.75:
                     config["apiversion"] = "1.75.0"
+
+                # Normalize legacy MotionAware persistence without treating
+                # config presence as a capability or enabling the feature.
+                _, motion_aware_issues = normalize_motion_aware_config(config)
+                for issue in motion_aware_issues:
+                    logging.warning("MotionAware config migration: %s", issue)
 
                 self.yaml_config["config"] = config
             else:

--- a/BridgeEmulator/flaskUI/v2restapi.py
+++ b/BridgeEmulator/flaskUI/v2restapi.py
@@ -10,7 +10,19 @@ from flask import request
 from services.entertainment import entertainmentService
 from threading import Thread
 from time import sleep
-from functions.core import nextFreeId
+from functions.core import nextFreeId, bridgeIdentity
+from functions.motionAware import (
+    createMotionAwareArea,
+    deleteMotionAwareArea,
+    isMotionAwareCandidateDevice,
+    updateMotionAwareResource,
+    v2MotionAreaCandidateService,
+    v2MotionAwareResources,
+)
+from motionAwareConfig import (
+    MOTION_AREA_CONFIGURATION,
+    SERVED_MOTION_RESOURCE_TYPES,
+)
 from datetime import datetime, timezone
 from functions.scripts import behaviorScripts
 from lights.discover import scanForLights
@@ -20,14 +32,93 @@ logging = logManager.logger.get_logger(__name__)
 
 bridgeConfig = configManager.bridgeConfig.yaml_config
 
+PRO_MOTION_RESOURCE_TYPES = SERVED_MOTION_RESOURCE_TYPES
+
+# Resource types reported by the `clip` capability resource on a
+# live BSB003 Hue Bridge Pro.
+#
+# `motion_area_candidate` is deliberately absent: Bridge Pro uses it
+# only as a ResourceIdentifier rtype on compatible device services and
+# MotionAware participants; it is not a served resource collection.
+PRO_CAPABILITY_RESOURCES = [
+    "motion_area_configuration",
+    "convenience_area_motion",
+    "security_area_motion",
+    "entertainment_configuration",
+    "bridge",
+    "button",
+    "device",
+    "device_power",
+    "device_software_update",
+    "entertainment",
+    "light",
+    "light_level",
+    "zigbee_connectivity",
+    "zgp_connectivity",
+    "motion",
+    "camera_motion",
+    "relative_rotary",
+    "temperature",
+    "zigbee_device_discovery",
+    "contact",
+    "tamper",
+    "speaker",
+    "bell_button",
+    "switch_input_configuration",
+    "bridge_home",
+    "grouped_light",
+    "grouped_light_level",
+    "grouped_motion",
+    "room",
+    "service_group",
+    "zone",
+    "scene",
+    "matter",
+    "matter_fabric",
+    "behavior_script",
+    "behavior_instance",
+    "geofence_client",
+    "geolocation",
+    "smart_scene",
+    "clip",
+]
+
+# Bridge Pro resource types that diyHue does not implement yet. They are
+# valid served collections in Pro mode, but remain empty until their
+# corresponding emulation is implemented.
+PRO_EMPTY_RESOURCE_TYPES = (
+    "device_software_update",
+    "zgp_connectivity",
+    "camera_motion",
+    "speaker",
+    "bell_button",
+    "switch_input_configuration",
+    "grouped_light_level",
+    "grouped_motion",
+    "service_group",
+    "matter",
+    "matter_fabric",
+)
+
 v2Resources = {"light": {}, "scene": {}, "smart_scene": {}, "grouped_light": {}, "room": {}, "zone": {
 }, "entertainment": {}, "entertainment_configuration": {}, "zigbee_connectivity": {}, "zigbee_device_discovery": {}, "device_power": {},
 "geofence_client": {}, "motion": {}, "light_level": {}, "temperature": {}, "relative_rotary": {}, "button": {}, "contact": {}, "tamper": {}}
 
 
 def getObject(element, v2uuid):
-    if element in ["behavior_instance", "device"]:
+    if element == "behavior_instance":
         return bridgeConfig[element][v2uuid]
+    elif element == "device":
+        # Device.id_v2 is derived again when its first service is attached.
+        # Older configs (and newly-created V1 devices) can therefore retain
+        # the pre-service UUID as the dictionary key while the V2 API exposes
+        # the derived UUID. Resolve the advertised UUID as well as the key.
+        if v2uuid in bridgeConfig[element]:
+            return bridgeConfig[element][v2uuid]
+        for device in bridgeConfig[element].values():
+            if device.id_v2 == v2uuid:
+                return device
+        raise KeyError(v2uuid)
     elif element in v2Resources and v2uuid in v2Resources[element]:
         logging.debug("Cache Hit for " + element)
         return v2Resources[element][v2uuid]()
@@ -171,38 +262,109 @@ def geoLocation():
     }
 
 
+
+
+def v2Device(device):
+    """Return a V2 device with Bridge Pro-only services when applicable."""
+    result = device.getDevice()
+
+    if isMotionAwareCandidateDevice(device):
+        candidate = v2MotionAreaCandidateService(device)
+
+        if candidate not in result["services"]:
+            result["services"].append(candidate)
+
+    return result
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def v2Clip():
+    config = bridgeConfig["config"]
+
+    if bridgeIdentity(config)["profile"] != "pro":
+        return None
+
+    return {
+        "id": str(uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            config["bridgeid"] + "clip"
+        )),
+        "resources": PRO_CAPABILITY_RESOURCES.copy(),
+        "type": "clip"
+    }
+
+
 def v2BridgeDevice():
     config = bridgeConfig["config"]
+    identity = bridgeIdentity(config)
     bridge_id = config["bridgeid"]
     result = {"id": str(uuid.uuid5(uuid.NAMESPACE_URL, bridge_id + 'device')), "type": "device"}
     result["id_v1"] = ""
-    result["metadata"] = {"archetype": "bridge_v2", "name": config["name"]}
+    result["metadata"] = {"archetype": identity["archetype"], "name": config["name"]}
     result["identify"] = {}
-    # Convert swversion to software_version format to match original bridge
-    # swversion is a 10-digit number (e.g., "1972076030")
-    # software_version should be in semantic version format
-    # TODO: Verify exact format by comparing with original bridge response
-    # Current implementation: convert "1972076030" -> "1.97.2076030"
-    swversion_str = config["swversion"]
-    if len(swversion_str) == 10:
-        # Convert 10-digit swversion to semantic version: X.XX.XXXXXX
-        software_version = f"{swversion_str[0]}.{swversion_str[1:3]}.{swversion_str[3:]}"
+    if identity["profile"] == "pro":
+        software_version = identity["software_version"]
     else:
-        # Fallback: use swversion as-is if format is unexpected
-        software_version = swversion_str
+        # Preserve the existing classic Bridge V2 conversion.
+        swversion_str = config["swversion"]
+        if len(swversion_str) == 10:
+            software_version = (
+                f"{swversion_str[0]}."
+                f"{swversion_str[1:3]}."
+                f"{swversion_str[3:]}"
+            )
+        else:
+            software_version = swversion_str
     result["product_data"] = {
         "certified": True,
         "manufacturer_name": "Signify Netherlands B.V.",
-        "model_id": "BSB002",
-        "product_archetype": "bridge_v2",
-        "product_name": "Philips hue",
+        "model_id": identity["modelid"],
+        "product_archetype": identity["archetype"],
+        "product_name": identity["product_name"],
         "software_version": software_version
     }
+    if identity["profile"] == "pro":
+        service_specs = [
+            ("bridge", "bridge"),
+            ("entertainment", "entertainment"),
+            (
+                "zigbee_device_discovery",
+                "zigbee_device_discovery"
+            )
+        ]
+    else:
+        service_specs = [
+            ("bridge", "bridge"),
+            ("zigbee_connectivity", "zigbee_connectivity"),
+            (
+                "zigbee_device_discovery",
+                "zigbee_device_discovery"
+            ),
+            ("entertainment", "entertainment")
+        ]
+
     result["services"] = [
-        {"rid": str(uuid.uuid5(uuid.NAMESPACE_URL, bridge_id + 'bridge')), "rtype": "bridge"},
-        {"rid": str(uuid.uuid5(uuid.NAMESPACE_URL, bridge_id + 'zigbee_connectivity')), "rtype": "zigbee_connectivity"},
-        {"rid": str(uuid.uuid5(uuid.NAMESPACE_URL, bridge_id + 'zigbee_device_discovery')), "rtype": "zigbee_device_discovery"},
-        {"rid": str(uuid.uuid5(uuid.NAMESPACE_URL, bridge_id + 'entertainment')), "rtype": "entertainment"}
+        {
+            "rid": str(uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                bridge_id + suffix
+            )),
+            "rtype": resource_type
+        }
+        for suffix, resource_type in service_specs
     ]
     return result
 
@@ -241,10 +403,19 @@ class ClipV2(Resource):
         # device
         data.append(v2BridgeDevice())
         for key, device in bridgeConfig["device"].items():
-            data.append(device.getDevice())
+            data.append(v2Device(device))
         # bridge
         data.append(v2Bridge())
         data.append(v2DiyHueBridge())
+
+        clip = v2Clip()
+        if clip is not None:
+            data.append(clip)
+
+        motion_aware = v2MotionAwareResources()
+        for resource_type in PRO_MOTION_RESOURCE_TYPES:
+            data.extend(motion_aware[resource_type])
+
         # zigbee
         data.append(v2BridgeZigBee())
         for key, device in bridgeConfig["device"].items():
@@ -365,7 +536,7 @@ class ClipV2Resource(Resource):
                     response["data"].append(group.getV2Api())
         elif resource == "device":
             for key, device in bridgeConfig["device"].items():
-                response["data"].append(device.getDevice())
+                response["data"].append(v2Device(device))
             response["data"].append(v2BridgeDevice())  # the bridge
         elif resource == "zigbee_device_discovery":
             response["data"].append(v2BridgeZigBeeDiscovery())
@@ -379,6 +550,26 @@ class ClipV2Resource(Resource):
             response["data"].append(v2HomeKit())
         elif resource == "geolocation":
             response["data"].append(geoLocation())
+        elif (
+            resource == "clip"
+            and bridgeIdentity(bridgeConfig["config"])["profile"] == "pro"
+        ):
+            response["data"].append(v2Clip())
+        elif (
+            resource in PRO_MOTION_RESOURCE_TYPES
+            and bridgeIdentity(bridgeConfig["config"])["profile"] == "pro"
+        ):
+            response["data"].extend(
+                v2MotionAwareResources()[resource]
+            )
+        elif (
+            resource in PRO_EMPTY_RESOURCE_TYPES
+            and bridgeIdentity(bridgeConfig["config"])["profile"] == "pro"
+        ):
+            # Valid Bridge Pro collections whose emulation is not yet
+            # implemented. An empty collection is preferable to
+            # advertising a capability and then returning Not Found.
+            pass
         elif resource == "behavior_instance":
             for key, instance in bridgeConfig["behavior_instance"].items():
                 response["data"].append(instance.getV2Api())
@@ -443,7 +634,30 @@ class ClipV2Resource(Resource):
         postDict = request.get_json(force=True)
         logging.info(postDict)
         newObject = None
-        if resource == "scene":
+        if resource == MOTION_AREA_CONFIGURATION:
+            try:
+                created = createMotionAwareArea(postDict)
+            except ValueError as error:
+                return {
+                    "data": [],
+                    "errors": [{"description": str(error)}]
+                }, 400
+
+            if created is None:
+                return {
+                    "data": [],
+                    "errors": [{"description": "MotionAware is unavailable"}]
+                }, 404
+
+            return {
+                "data": [{
+                    **created,
+                    "rid": created["id"],
+                    "rtype": resource
+                }],
+                "errors": []
+            }, 201
+        elif resource == "scene":
             new_object_id = nextFreeId(bridgeConfig, "scenes")
             objCreation = {
                 "id_v1": new_object_id,
@@ -652,6 +866,25 @@ class ClipV2ResourceId(Resource):
         if "user" not in authorisation:
             return "", 403
         
+        # Bridge Pro capability resources are not stored in the
+        # regular V1-backed object collections.
+        if bridgeIdentity(bridgeConfig["config"])["profile"] == "pro":
+            if resource == "clip":
+                clip = v2Clip()
+                if resourceid == clip["id"]:
+                    return {"errors": [], "data": [clip]}
+                return {"errors": [], "data": []}
+
+            if resource in PRO_MOTION_RESOURCE_TYPES:
+                for item in v2MotionAwareResources()[resource]:
+                    if item["id"] == resourceid:
+                        return {"errors": [], "data": [item]}
+
+                return {"errors": [], "data": []}
+
+            if resource in PRO_EMPTY_RESOURCE_TYPES:
+                return {"errors": [], "data": []}
+
         # Special handling for bridge device (not stored in bridgeConfig["device"])
         if resource == "device":
             bridge_device_id = str(uuid.uuid5(uuid.NAMESPACE_URL, bridgeConfig["config"]["bridgeid"] + 'device'))
@@ -669,7 +902,7 @@ class ClipV2ResourceId(Resource):
         elif resource == "grouped_light":
             return {"errors": [], "data": [object.getV2GroupedLight()]}
         elif resource == "device":
-            return {"errors": [], "data": [object.getDevice()]}
+            return {"errors": [], "data": [v2Device(object)]}
         elif resource == "zigbee_connectivity":
             return {"errors": [], "data": [object.getZigBee()]}
         elif resource == "zigbee_device_discovery":
@@ -704,6 +937,42 @@ class ClipV2ResourceId(Resource):
             return "", 403
         putDict = request.get_json(force=True)
         logging.info(putDict)
+
+        if (
+            resource in PRO_MOTION_RESOURCE_TYPES
+            and bridgeIdentity(bridgeConfig["config"])["profile"] == "pro"
+        ):
+            try:
+                updated = updateMotionAwareResource(
+                    resource,
+                    resourceid,
+                    putDict
+                )
+            except ValueError as err:
+                return {
+                    "errors": [{
+                        "description": str(err)
+                    }]
+                }, 400
+
+            if updated is None:
+                return {
+                    "errors": [{
+                        "description": (
+                            "MotionAware resource not found: "
+                            + resourceid
+                        )
+                    }]
+                }, 404
+
+            return {
+                "data": [{
+                    "rid": resourceid,
+                    "rtype": resource
+                }],
+                "errors": []
+            }
+
         object = getObject(resource, resourceid)
         if resource == "light":
             object.setV2State(putDict)
@@ -933,6 +1202,16 @@ class ClipV2ResourceId(Resource):
         authorisation = authorizeV2(request.headers)
         if "user" not in authorisation:
             return "", 403
+
+        if resource == MOTION_AREA_CONFIGURATION:
+            if not deleteMotionAwareArea(resourceid):
+                return {
+                    "data": [],
+                    "errors": [{"description": "MotionAware resource not found"}]
+                }, 404
+
+            return {"data": [{"rid": resourceid, "rtype": resource}], "errors": []}
+
         object = getObject(resource, resourceid)
         
         if resource == "device":

--- a/BridgeEmulator/functions/behavior_instance.py
+++ b/BridgeEmulator/functions/behavior_instance.py
@@ -3,11 +3,14 @@ import configManager
 import uuid
 import random
 from datetime import datetime
-from threading import Thread
+from threading import Thread, RLock
 from time import sleep
 logging = logManager.logger.get_logger(__name__)
 bridgeConfig = configManager.bridgeConfig.yaml_config
 from pprint import pprint
+
+_motion_area_lock = RLock()
+_motion_area_generation = {}
 
 def findTriggerTime(times):
     numberOfIntervals = len(times)
@@ -93,10 +96,162 @@ def executeActions(actionsToExecute, groupsAndLights):
         for action in actionsToExecute[recall]:
             if action["action"] == "all_off":
                 for resource in groupsAndLights:
+                    if resource is None:
+                        continue
                     resource.setV1Action({"on": False})
                     logging.info("routine turning lights off " + resource.name)
             elif "recall" in action["action"] and action["action"]["recall"]["rtype"] == "scene":
                 callScene(action["action"]["recall"]["rid"])
+
+
+def _motionAreaTargets(configuration):
+    """Resolve the Hue behavior `motion.where` targets."""
+    motion = configuration.get("motion", {})
+    where = motion.get("where", []) if isinstance(motion, dict) else []
+    if not where:
+        where = configuration.get("where", [])
+
+    targets = []
+    for resource in where:
+        if not isinstance(resource, dict):
+            continue
+        if isinstance(resource.get("group"), dict):
+            group_ref = resource["group"]
+            target = findGroup(group_ref.get("rid"), group_ref.get("rtype"))
+        elif isinstance(resource.get("light"), dict):
+            light_ref = resource["light"]
+            target = findLight(light_ref.get("rid"), light_ref.get("rtype"))
+        else:
+            target = None
+        if target is not None:
+            targets.append(target)
+    return targets
+
+
+def _motionAreaSlotActions(configuration, event):
+    """Select the current Hue timeslot and return its motion actions."""
+    motion = configuration.get("motion", {})
+    when = motion.get("when", {}) if isinstance(motion, dict) else {}
+    slots = when.get("timeslots", []) if isinstance(when, dict) else []
+    if not isinstance(slots, list) or not slots:
+        return {}
+
+    normalized = []
+    for slot in slots:
+        if not isinstance(slot, dict):
+            continue
+        start_time = slot.get("start_time", {})
+        time_value = start_time.get("time", start_time)
+        if not isinstance(time_value, dict):
+            continue
+        try:
+            hour = int(time_value["hour"])
+            minute = int(time_value["minute"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        normalized.append({
+            "hour": hour,
+            "minute": minute,
+            "actions": slot.get("on_motion" if event else "on_no_motion", {}),
+        })
+
+    if not normalized:
+        return {}
+    return findTriggerTime(normalized)
+
+
+def _motionAreaDelaySeconds(actions):
+    for key in ("after", "timer"):
+        value = actions.get(key) if isinstance(actions, dict) else None
+        if not isinstance(value, dict):
+            continue
+        if key == "timer":
+            value = value.get("duration", {})
+        if not isinstance(value, dict):
+            continue
+        try:
+            return int(value.get("minutes", 0)) * 60 + int(value.get("seconds", 0))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _motionAreaDelayedNoMotion(area_id, actions, targets, generation):
+    delay = _motionAreaDelaySeconds(actions)
+    if delay:
+        sleep(delay)
+    with _motion_area_lock:
+        if _motion_area_generation.get(area_id) != generation:
+            return
+    executeActions(actions, targets)
+
+
+def checkMotionAwareBehaviorInstances(area_id, motion):
+    """Execute Hue-created local behaviors for a MotionAware transition.
+
+    MotionAware is a service source, not a physical sensor device, so the
+    existing ``checkBehaviorInstances(device)`` dispatcher cannot reach these
+    instances.  This narrow adapter consumes the stock behavior shape and
+    reuses the established scene/group executor.
+    """
+    if not isinstance(area_id, str) or not isinstance(motion, bool):
+        return 0
+
+    with _motion_area_lock:
+        generation = _motion_area_generation.get(area_id, 0) + 1
+        _motion_area_generation[area_id] = generation
+
+    # Editing/recreating an area can leave historical instances in the
+    # datastore.  They share the same MotionArea source but may recall stale
+    # scenes.  The last persisted matching instance is the current app
+    # configuration; dispatch only that one.
+    matching = []
+    for instance in bridgeConfig.get("behavior_instance", {}).values():
+        if not getattr(instance, "enabled", False):
+            continue
+        configuration = getattr(instance, "configuration", {})
+        if not isinstance(configuration, dict):
+            continue
+        source = configuration.get("source", {})
+        if (
+            not isinstance(source, dict)
+            or source.get("rtype") != "motion_area_configuration"
+            or source.get("rid") != area_id
+        ):
+            continue
+
+        matching.append(instance)
+
+    if not matching:
+        return 0
+
+    executed = 0
+    for instance in matching[-1:]:
+        configuration = getattr(instance, "configuration", {})
+
+        targets = _motionAreaTargets(configuration)
+        if not targets:
+            logging.warning(
+                "MotionAware behavior %s has no resolvable targets",
+                getattr(instance, "id_v2", "unknown"),
+            )
+            continue
+
+        actions = _motionAreaSlotActions(configuration, motion)
+        if not isinstance(actions, dict):
+            continue
+
+        if motion:
+            executeActions(actions, targets)
+        else:
+            Thread(
+                target=_motionAreaDelayedNoMotion,
+                args=(area_id, actions, targets, generation),
+                daemon=True,
+            ).start()
+        executed += 1
+
+    return executed
 
 
 def checkBehaviorInstances(device):

--- a/BridgeEmulator/functions/core.py
+++ b/BridgeEmulator/functions/core.py
@@ -1,5 +1,41 @@
 from datetime import datetime, timezone
 
+
+def bridgeIdentity(config=None):
+    if config and config.get("bridge_profile") == "pro":
+        return {
+            "profile": "pro",
+            "modelid": "BSB003",
+            "archetype": "bridge_v3",
+            "product_name": "Hue Bridge",
+            "swversion": "2071442000",
+            "apiversion": "1.78.0",
+            "software_version": "1.78.2071442000"
+        }
+
+    return {
+        "profile": "classic",
+        "modelid": "BSB002",
+        "archetype": "bridge_v2",
+        "product_name": "Philips hue",
+        "swversion": None,
+        "apiversion": None,
+        "software_version": None
+    }
+
+
+def bridgeReportedSwversion(config):
+    """Return the externally reported firmware for the active profile."""
+    identity = bridgeIdentity(config)
+    return identity["swversion"] or config["swversion"]
+
+
+def bridgeReportedApiversion(config):
+    """Return the externally reported API version for the active profile."""
+    identity = bridgeIdentity(config)
+    return identity["apiversion"] or config["apiversion"]
+
+
 def nextFreeId(bridgeConfig, element):
     i = 1
     while (str(i)) in bridgeConfig[element]:
@@ -7,7 +43,8 @@ def nextFreeId(bridgeConfig, element):
     return str(i)
 
 
-def staticConfig():
+def staticConfig(config=None):
+    identity = bridgeIdentity(config)
     return {
         "backup": {
             "errorcode": 0,
@@ -23,7 +60,7 @@ def staticConfig():
             "time": "disconnected"
         },
         "linkbutton": False,
-        "modelid": "BSB002",
+        "modelid": identity["modelid"],
         "portalconnection": "disconnected",
         "portalservices": False,
         "analyticsconsent": False,

--- a/BridgeEmulator/functions/motionAware.py
+++ b/BridgeEmulator/functions/motionAware.py
@@ -1,0 +1,1021 @@
+import uuid
+import configManager
+import logManager
+
+from datetime import datetime, timezone
+from threading import RLock
+from HueObjects import StreamEvent
+from functions.core import bridgeIdentity
+from motionAwareConfig import (
+    CONVENIENCE_AREA_MOTION,
+    DEFAULT_AREA_ENABLED,
+    DEFAULT_HEALTH,
+    DEFAULT_SENSITIVITY,
+    DEFAULT_SERVICE_ENABLED,
+    MAX_SENSITIVITY,
+    MOTION_AREA_CANDIDATE,
+    MOTION_AREA_CONFIGURATION,
+    MOTION_SERVICE_TYPES,
+    SECURITY_AREA_MOTION,
+    SERVED_MOTION_RESOURCE_TYPES,
+    VALID_GROUP_TYPES,
+    get_motion_aware_areas,
+    get_stored_area,
+    read_bool,
+    read_int,
+    read_health,
+    read_nonempty_string,
+    read_participants,
+    read_resource_reference,
+)
+
+
+logging = logManager.logger.get_logger(__name__)
+bridgeConfig = configManager.bridgeConfig.yaml_config
+
+# Runtime RF state is intentionally process-local. Config persistence stores
+# user configuration only; a restart must not resurrect a stale motion event.
+_runtime_lock = RLock()
+_runtime_motion = {}
+_quiet_changed = {}
+
+
+def _utcTimestamp():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def isMotionAwareAvailable():
+    """Capability is a Bridge Pro property, never inferred from data presence."""
+    config = bridgeConfig.get("config", {})
+    return bridgeIdentity(config)["profile"] == "pro"
+
+
+def motionAwareStoredAreas():
+    """Return persisted MotionAware overrides without mutating config."""
+    return get_motion_aware_areas(bridgeConfig.get("config", {}))
+
+
+def motionAwareStoredArea(area_id):
+    return get_stored_area(bridgeConfig.get("config", {}), area_id)
+
+
+def _storedAreasForWrite():
+    return get_motion_aware_areas(bridgeConfig["config"], create=True)
+
+
+def motionAwareRuntimeState(area_id):
+    with _runtime_lock:
+        state = _runtime_motion.get(area_id)
+        if state is None:
+            return None
+        motion = bool(state["motion"])
+        return {
+            "motion": motion,
+            "motion_valid": True,
+            "motion_report": {
+                "changed": state["changed"],
+                "motion": motion,
+            },
+        }
+
+
+def clearMotionAwareRuntime(area_id):
+    with _runtime_lock:
+        _runtime_motion.pop(area_id, None)
+        _quiet_changed.pop(area_id, None)
+
+
+def v2MotionAreaCandidateService(device):
+    """Return the reference-only MotionAware service for a light device."""
+    return {
+        "rid": str(uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            device.id_v2 + "motion_area_candidate"
+        )),
+        "rtype": MOTION_AREA_CANDIDATE
+    }
+
+
+def devicesForGroup(group):
+    """Resolve live light-device members and ignore dangling weakrefs."""
+    result = []
+    seen = set()
+    for reference in getattr(group, "lights", []):
+        device = reference() if callable(reference) else reference
+        device_id = getattr(device, "id_v2", None)
+        if (
+            device is None
+            or not isinstance(device_id, str)
+            or not device_id
+            or not hasattr(device, "getDevice")
+            or device_id in seen
+        ):
+            continue
+        seen.add(device_id)
+        result.append(device)
+    result.sort(key=lambda item: item.id_v2)
+    return result
+
+
+def _candidateIsReachable(device):
+    """A missing reachability field is legacy-compatible; explicit false is not."""
+    try:
+        state = device.firstElement().state
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return True
+    return state.get("reachable") is not False
+
+
+def isMotionAwareCandidateDevice(device):
+    """Whether a Pro light exposes the candidate capability service.
+
+    Reachability is dynamic state, not capability.  Keeping the service on an
+    unreachable device preserves references for an existing area; the create
+    validator still filters unreachable devices via ``motionAwareCandidates``.
+    """
+    return (
+        isMotionAwareAvailable()
+        and getattr(device, "group_v1", None) == "lights"
+        and hasattr(device, "getDevice")
+    )
+
+
+def motionAwareCandidates(candidate_ids=None):
+    """Return every advertised, reachable Pro candidate keyed by candidate RID."""
+    if not isMotionAwareAvailable():
+        return {}
+
+    wanted = set(candidate_ids or ())
+    result = {}
+    for device in bridgeConfig.get("device", {}).values():
+        if not isMotionAwareCandidateDevice(device):
+            continue
+        if not _candidateIsReachable(device):
+            continue
+        candidate = v2MotionAreaCandidateService(device)
+        if not wanted or candidate["rid"] in wanted:
+            result[candidate["rid"]] = device
+    return result
+
+
+def allMotionAwareCandidates(candidate_ids=None):
+    """Resolve candidate services including temporarily unreachable lights.
+
+    This is used only when rendering persisted areas.  A configured area must
+    remain visible with participant health ``unhealthy`` while a light is
+    offline; otherwise the API would emit dangling references or hide the
+    entire area and the Hue client could not recover it after reconnect.
+    """
+    if not isMotionAwareAvailable():
+        return {}
+    wanted = set(candidate_ids or ())
+    result = {}
+    for device in bridgeConfig.get("device", {}).values():
+        if not isMotionAwareCandidateDevice(device):
+            continue
+        candidate = v2MotionAreaCandidateService(device)
+        if not wanted or candidate["rid"] in wanted:
+            result[candidate["rid"]] = device
+    return result
+
+
+def usedMotionAwareCandidateIds(exclude_area_id=None):
+    """Return participant candidate IDs reserved by persisted areas.
+
+    The Hue client receives candidates as device services, while a configured
+    area records which of those services it owns.  Keeping that allocation in
+    one place prevents two areas from silently claiming the same light.
+    Invalid legacy records are ignored here; they are not valid allocations.
+    """
+    used = set()
+    for area_id, area in motionAwareStoredAreas().items():
+        if area_id == exclude_area_id or not isinstance(area, dict):
+            continue
+        participants = read_participants(area.get("participants"))
+        if participants is None:
+            continue
+        used.update(item["resource"]["rid"] for item in participants)
+    return used
+
+
+def _validateCandidateSelection(candidate_ids, exclude_area_id=None):
+    """Resolve a 3--4 light selection and reject unreachable/reused IDs."""
+    if not isinstance(candidate_ids, list) or not 3 <= len(candidate_ids) <= 4:
+        raise ValueError("participants must contain three or four devices")
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("participants must be unique")
+
+    candidates = motionAwareCandidates(candidate_ids)
+    if len(candidates) != len(candidate_ids):
+        raise ValueError("participants must reference eligible candidates")
+
+    reused = set(candidate_ids) & usedMotionAwareCandidateIds(exclude_area_id)
+    if reused:
+        raise ValueError("participants are already assigned to another MotionAware area")
+
+    return candidates
+
+
+def v2GroupReference(group):
+    """Map an existing diyHue group to the exact V2 reference it exposes."""
+    group_type = getattr(group, "type", None)
+    if getattr(group, "id_v1", None) == "0":
+        return {
+            "rid": str(uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                group.id_v2 + "bridge_home",
+            )),
+            "rtype": "bridge_home",
+        }
+    if group_type == "Room":
+        return {"rid": group.getV2Room()["id"], "rtype": "room"}
+    if group_type == "Zone":
+        return {"rid": group.getV2Zone()["id"], "rtype": "zone"}
+    return None
+
+
+def groupForMotionAwareReference(reference):
+    """Resolve a stored V2 group reference without creating dangling links."""
+    reference = read_resource_reference(reference, VALID_GROUP_TYPES)
+    if reference is None:
+        return None
+    for group in bridgeConfig.get("groups", {}).values():
+        if v2GroupReference(group) == reference:
+            return group
+    return None
+
+
+def v2MotionAwareRooms():
+    """Legacy compatibility helper for old room-derived area identifiers."""
+    if not isMotionAwareAvailable():
+        return []
+    result = []
+    for group in bridgeConfig.get("groups", {}).values():
+        if getattr(group, "type", None) != "Room":
+            continue
+        devices = devicesForGroup(group)
+        if 3 <= len(devices) <= 4:
+            result.append((group, devices))
+    result.sort(key=lambda item: item[0].getV2Room()["id"])
+    return result
+
+
+def v2MotionAreaIds(group):
+    """Legacy stable IDs retained for pre-subset room-backed areas."""
+    room_id = group.getV2Room()["id"]
+    area_id = str(uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        room_id + MOTION_AREA_CONFIGURATION,
+    ))
+    return v2MotionAreaServiceIds(area_id, area_id)
+
+
+def v2MotionAreaServiceIds(area_id, legacy_area_id=None):
+    """Return stable service IDs for any persisted area ID."""
+    legacy_area_id = legacy_area_id or area_id
+    convenience_id = str(uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        legacy_area_id + CONVENIENCE_AREA_MOTION,
+    ))
+    security_id = str(uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        legacy_area_id + SECURITY_AREA_MOTION,
+    ))
+    return area_id, convenience_id, security_id
+
+
+def newMotionAreaId(group_reference, candidate_ids):
+    """Deterministic ID supports multiple areas without random/restart churn."""
+    seed = "|".join((
+        MOTION_AREA_CONFIGURATION,
+        group_reference["rtype"],
+        group_reference["rid"],
+        *sorted(candidate_ids),
+    ))
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
+
+
+def _legacyGroupForArea(area_id):
+    for group, _devices in v2MotionAwareRooms():
+        legacy_area_id, _convenience_id, _security_id = v2MotionAreaIds(group)
+        if legacy_area_id == area_id:
+            return group
+    return None
+
+
+def v2MotionAreaDevices(group, area_id):
+    """Use persisted candidate refs; only legacy entries fall back to a room."""
+    stored = motionAwareStoredArea(area_id)
+    if "participants" in stored:
+        participants = read_participants(stored.get("participants"))
+        if participants is None or not 3 <= len(participants) <= 4:
+            return []
+        candidate_ids = [item["resource"]["rid"] for item in participants]
+        candidates = allMotionAwareCandidates(candidate_ids)
+        if len(candidates) != len(candidate_ids):
+            return []
+        return [candidates[candidate_id] for candidate_id in candidate_ids]
+
+    # Pre-subset datastore records had no participant list and were tied to
+    # one room. Preserve that behavior without treating it as new schema.
+    return devicesForGroup(group) if group is not None else []
+
+
+def v2MotionAreaConfiguration(group, devices, area_id):
+    _area_id, convenience_id, security_id = v2MotionAreaServiceIds(area_id)
+    stored = motionAwareStoredArea(area_id)
+    default_group = v2GroupReference(group)
+    group_reference = read_resource_reference(
+        stored.get("group"), VALID_GROUP_TYPES
+    ) or default_group
+    return {
+        "id": area_id,
+        "name": read_nonempty_string(
+            stored,
+            "name",
+            getattr(group, "name", "Motion area"),
+        ),
+        "group": group_reference,
+        "participants": [
+            {
+                "resource": v2MotionAreaCandidateService(device),
+                "status": {
+                    # Reachability is live participant health.  Do not hide
+                    # an otherwise valid area while a light is offline.
+                    "health": (
+                        "healthy"
+                        if _candidateIsReachable(device)
+                        else "unhealthy"
+                    )
+                }
+            }
+            for device in devices
+        ],
+        "services": [
+            {
+                "rid": convenience_id,
+                "rtype": CONVENIENCE_AREA_MOTION
+            },
+            {
+                "rid": security_id,
+                "rtype": SECURITY_AREA_MOTION
+            }
+        ],
+        "health": read_health(stored),
+        "enabled": read_bool(stored, "enabled", DEFAULT_AREA_ENABLED),
+        "type": MOTION_AREA_CONFIGURATION
+    }
+
+
+def v2MotionAwareSources(group):
+    """Return regular diyHue motion sources assigned to a room."""
+    result = []
+
+    for member_ref in getattr(group, "sensors", []):
+        member = member_ref() if callable(member_ref) else member_ref
+
+        if member is None:
+            continue
+
+        if hasattr(member, "getMotion"):
+            motion = member.getMotion()
+
+            if motion is not None:
+                result.append(member)
+                continue
+
+        if getattr(member, "type", None) == "ZLLPresence":
+            result.append(member)
+
+    result.sort(
+        key=lambda item: getattr(
+            item,
+            "id_v2",
+            getattr(item, "id_v1", "")
+        )
+    )
+
+    return result
+
+
+def v2MotionAwareState(group, area_id):
+    """Aggregate ordinary room motion sensors into one area state."""
+    runtime_state = motionAwareRuntimeState(area_id)
+    if runtime_state is not None:
+        return runtime_state
+
+    reports = []
+
+    for source in v2MotionAwareSources(group):
+        if hasattr(source, "getMotion"):
+            resource = source.getMotion()
+
+            if resource is None or not resource.get("enabled", True):
+                continue
+
+            motion = resource.get("motion", {})
+
+            if "motion" not in motion:
+                continue
+
+            changed = (
+                motion.get("motion_report") or {}
+            ).get("changed")
+
+            reports.append({
+                "motion": bool(motion["motion"]),
+                "changed": changed
+            })
+
+        elif getattr(source, "type", None) == "ZLLPresence":
+            if not source.config.get("on", True):
+                continue
+
+            if "presence" not in source.state:
+                continue
+
+            reports.append({
+                "motion": bool(source.state["presence"]),
+                "changed": source.state.get("lastupdated")
+            })
+
+    if not reports:
+        return {
+            "motion": False,
+            # A room containing only light participants has no native motion
+            # source. Treat the observed quiet state as valid so the stock
+            # calibration flow can complete while the area is empty.
+            "motion_valid": True,
+            # A quiet timestamp is stable until a real transition occurs.
+            "motion_report": {
+                "changed": _quietChanged(area_id),
+                "motion": False
+            }
+        }
+
+    result = {
+        "motion": any(report["motion"] for report in reports),
+        "motion_valid": True
+    }
+
+    changed = sorted(
+        report["changed"]
+        for report in reports
+        if report["changed"]
+        and report["changed"] != "none"
+    )
+
+    if changed:
+        result["motion_report"] = {
+            "changed": changed[-1],
+            "motion": result["motion"]
+        }
+
+    return result
+
+
+def _quietChanged(area_id):
+    with _runtime_lock:
+        changed = _quiet_changed.get(area_id)
+        if changed is None:
+            changed = _utcTimestamp()
+            _quiet_changed[area_id] = changed
+        return changed
+
+
+def v2AreaMotion(group, area_id, resource_id, resource_type):
+    stored = (
+        motionAwareStoredArea(area_id)
+        .get(resource_type, {})
+    )
+
+    return {
+        "id": resource_id,
+        "owner": {
+            "rid": area_id,
+            "rtype": "motion_area_configuration"
+        },
+        "enabled": read_bool(stored, "enabled", DEFAULT_SERVICE_ENABLED),
+        "motion": v2MotionAwareState(group, area_id),
+        "sensitivity": {
+            "sensitivity": read_int(
+                stored,
+                "sensitivity",
+                DEFAULT_SENSITIVITY,
+                minimum=0,
+                maximum=MAX_SENSITIVITY,
+            ),
+            "sensitivity_max": MAX_SENSITIVITY
+        },
+        "type": resource_type
+    }
+
+
+def v2MotionAwareResources():
+    resources = {
+        MOTION_AREA_CONFIGURATION: [],
+        CONVENIENCE_AREA_MOTION: [],
+        SECURITY_AREA_MOTION: [],
+    }
+
+    if not isMotionAwareAvailable():
+        return resources
+
+    for area_id, stored_area in sorted(motionAwareStoredAreas().items()):
+        if not isinstance(area_id, str) or not isinstance(stored_area, dict):
+            continue
+
+        group = groupForMotionAwareReference(stored_area.get("group"))
+        if group is None:
+            group = _legacyGroupForArea(area_id)
+        if group is None:
+            logging.warning(
+                "Ignoring MotionAware area with unresolved group: %s",
+                area_id,
+            )
+            continue
+
+        devices = v2MotionAreaDevices(group, area_id)
+        if not 3 <= len(devices) <= 4:
+            logging.warning(
+                "Ignoring MotionAware area with unavailable participants: %s",
+                area_id,
+            )
+            continue
+
+        _area_id, convenience_id, security_id = v2MotionAreaServiceIds(area_id)
+
+        resources[MOTION_AREA_CONFIGURATION].append(
+            v2MotionAreaConfiguration(group, devices, area_id)
+        )
+
+        resources[CONVENIENCE_AREA_MOTION].append(
+            v2AreaMotion(
+                group,
+                area_id,
+                convenience_id,
+                CONVENIENCE_AREA_MOTION
+            )
+        )
+
+        resources[SECURITY_AREA_MOTION].append(
+            v2AreaMotion(
+                group,
+                area_id,
+                security_id,
+                SECURITY_AREA_MOTION
+            )
+        )
+
+    return resources
+
+
+def findMotionAwareResource(resource_type, resource_id):
+    """Resolve one generated MotionAware resource by V2 id."""
+    if resource_type not in SERVED_MOTION_RESOURCE_TYPES:
+        return None
+
+    for resource in v2MotionAwareResources()[resource_type]:
+        if resource["id"] == resource_id:
+            return resource
+
+    return None
+
+
+def _streamMotionAwareResources(event_type, resources):
+    """Publish independently decodable MotionAware resource events."""
+    for resource in resources:
+        StreamEvent({
+            "creationtime": _utcTimestamp(),
+            "data": [resource],
+            "id": str(uuid.uuid4()),
+            "type": event_type,
+        })
+
+
+def createMotionAwareArea(data):
+    """Create an area from the candidate references sent by the Hue app."""
+    if not isMotionAwareAvailable():
+        return None
+
+    if not isinstance(data, dict):
+        raise ValueError("POST body must be an object")
+
+    name = data.get("name")
+    group_ref = data.get("group")
+    participants = data.get("participants")
+
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("name must be a non-empty string")
+
+    group_ref = read_resource_reference(group_ref, VALID_GROUP_TYPES)
+    if group_ref is None:
+        raise ValueError("group must reference a bridge_home, room, or zone")
+    if groupForMotionAwareReference(group_ref) is None:
+        raise ValueError("group must reference an existing bridge_home, room, or zone")
+
+    if not isinstance(participants, list) or not 3 <= len(participants) <= 4:
+        raise ValueError("participants must contain three or four devices")
+
+    candidate_ids = []
+
+    for participant in participants:
+        resource = participant.get("resource", {}) if isinstance(participant, dict) else {}
+
+        if (
+            resource.get("rtype") != MOTION_AREA_CANDIDATE
+            or not isinstance(resource.get("rid"), str)
+            or not resource["rid"]
+        ):
+            raise ValueError("each participant must reference a motion_area_candidate")
+
+        candidate_ids.append(resource["rid"])
+
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("participants must be unique")
+
+    # Hue 5.73 permits a subset of three or four reachable candidate lights
+    # and permits further areas when they use unused candidates.  Do not
+    # reintroduce the obsolete "all lights in one 3--4 device room" rule.
+    _validateCandidateSelection(candidate_ids)
+    area_id = newMotionAreaId(group_ref, candidate_ids)
+    areas = _storedAreasForWrite()
+    if area_id in areas:
+        raise ValueError("an area with these participants already exists")
+
+    area = {}
+    areas[area_id] = area
+    area["name"] = name.strip()
+    area["group"] = {
+        "rid": group_ref["rid"],
+        "rtype": group_ref["rtype"]
+    }
+    if not isinstance(area.get("enabled"), bool):
+        area["enabled"] = DEFAULT_AREA_ENABLED
+    area["participants"] = [
+        {
+            "resource": {
+                "rid": candidate_id,
+                "rtype": MOTION_AREA_CANDIDATE,
+            },
+            "status": {"health": DEFAULT_HEALTH},
+        }
+        for candidate_id in candidate_ids
+    ]
+    # The stock app waits for a healthy area event before leaving the
+    # creation screen.  A diyHue-backed room has no hardware calibration
+    # phase, so expose the ready state immediately.
+    area["health"] = DEFAULT_HEALTH
+
+    configManager.bridgeConfig.save_config(backup=False, resource="config")
+
+    resources = v2MotionAwareResources()
+    created = findMotionAwareResource(MOTION_AREA_CONFIGURATION, area_id)
+    if created is None:
+        # Never persist an area that cannot be represented by the served
+        # resource graph.  This is a defensive rollback for legacy/dangling
+        # device state discovered between validation and rendering.
+        del areas[area_id]
+        configManager.bridgeConfig.save_config(backup=False, resource="config")
+        raise ValueError("created MotionAware area is not representable")
+
+    event_data = [created]
+
+    for resource_type in MOTION_SERVICE_TYPES:
+        event_data.extend(
+            item for item in resources[resource_type]
+            if item["owner"]["rid"] == area_id
+        )
+
+    _streamMotionAwareResources("add", event_data)
+
+    return created
+
+
+def deleteMotionAwareArea(area_id):
+    """Delete a persisted MotionAware area and all generated services."""
+    areas = motionAwareStoredAreas()
+
+    if area_id not in areas:
+        return False
+
+    _area_id, convenience_id, security_id = v2MotionAreaServiceIds(area_id)
+    service_ids = [convenience_id, security_id]
+    del areas[area_id]
+    configManager.bridgeConfig.save_config(backup=False, resource="config")
+
+    StreamEvent({
+        "creationtime": _utcTimestamp(),
+        "data": [
+            {"id": area_id, "type": MOTION_AREA_CONFIGURATION},
+            *[
+                {"id": service_id, "type": resource_type}
+                for service_id, resource_type in zip(
+                    service_ids,
+                    MOTION_SERVICE_TYPES
+                )
+            ]
+        ],
+        "id": str(uuid.uuid4()),
+        "type": "delete"
+    })
+
+    clearMotionAwareRuntime(area_id)
+
+    return True
+
+
+def updateMotionAwareResource(resource_type, resource_id, data):
+    """Persist a supported MotionAware V2 PUT and emit its SSE update."""
+    if not isMotionAwareAvailable():
+        return None
+
+    current = findMotionAwareResource(
+        resource_type,
+        resource_id
+    )
+
+    if current is None:
+        return None
+
+    if not isinstance(data, dict):
+        raise ValueError("PUT body must be an object")
+
+    if "id" in data and data["id"] != resource_id:
+        raise ValueError("id does not match the addressed resource")
+
+    area_id = (
+        resource_id
+        if resource_type == "motion_area_configuration"
+        else current["owner"]["rid"]
+    )
+
+    changes = {}
+
+    if resource_type == "motion_area_configuration":
+        unsupported = set(data) - {"id", "name", "group", "participants", "enabled"}
+        if unsupported:
+            raise ValueError("unsupported MotionAware configuration fields")
+
+        if "name" in data:
+            if (
+                not isinstance(data["name"], str)
+                or not data["name"].strip()
+            ):
+                raise ValueError("name must be a non-empty string")
+
+            changes["name"] = data["name"].strip()
+
+        if "enabled" in data:
+            if not isinstance(data["enabled"], bool):
+                raise ValueError("enabled must be boolean")
+
+            changes["enabled"] = data["enabled"]
+
+        if "group" in data:
+            group = read_resource_reference(data["group"], VALID_GROUP_TYPES)
+            if group is None or groupForMotionAwareReference(group) is None:
+                raise ValueError("group must reference an existing bridge_home, room, or zone")
+            changes["group"] = group
+
+        if "participants" in data:
+            participants = read_participants(data["participants"])
+            if participants is None or not 3 <= len(participants) <= 4:
+                raise ValueError(
+                    "participants must contain three or four unique candidates"
+                )
+
+            candidate_ids = [
+                participant["resource"]["rid"]
+                for participant in participants
+            ]
+            _validateCandidateSelection(candidate_ids, exclude_area_id=area_id)
+            changes["participants"] = participants
+
+    else:
+        unsupported = set(data) - {"id", "enabled", "sensitivity"}
+        if unsupported:
+            raise ValueError("unsupported MotionAware service fields")
+
+        if "enabled" in data:
+            if not isinstance(data["enabled"], bool):
+                raise ValueError("enabled must be boolean")
+
+            changes["enabled"] = data["enabled"]
+
+        if "sensitivity" in data:
+            sensitivity = data["sensitivity"]
+
+            if not isinstance(sensitivity, dict):
+                raise ValueError(
+                    "sensitivity must be an object"
+                )
+
+            if "sensitivity" not in sensitivity:
+                raise ValueError(
+                    "sensitivity.sensitivity is required"
+                )
+
+            value = sensitivity["sensitivity"]
+
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not 0 <= value <= MAX_SENSITIVITY
+            ):
+                raise ValueError(
+                    "sensitivity must be an integer from 0 to 4"
+                )
+
+            changes["sensitivity"] = value
+
+    if not changes:
+        return current
+
+    # Do not persist or emit an SSE update when the requested
+    # properties already match the generated resource state.
+    effective_changes = {}
+
+    for key, value in changes.items():
+        if key == "sensitivity":
+            current_value = (
+                current.get("sensitivity", {})
+                .get("sensitivity")
+            )
+        else:
+            current_value = current.get(key)
+
+        if current_value != value:
+            effective_changes[key] = value
+
+    changes = effective_changes
+
+    if not changes:
+        return current
+
+    areas = _storedAreasForWrite()
+    area = areas.setdefault(
+        area_id,
+        {}
+    )
+    if not isinstance(area, dict):
+        area = {}
+        areas[area_id] = area
+
+    if resource_type == "motion_area_configuration":
+        area.update(changes)
+    else:
+        service = area.setdefault(
+            resource_type,
+            {}
+        )
+        service.update(changes)
+
+    configManager.bridgeConfig.save_config(
+        backup=False,
+        resource="config"
+    )
+
+    updated = findMotionAwareResource(
+        resource_type,
+        resource_id
+    )
+
+    # Hue's typed MotionAware reducer consumes complete resources. Partial
+    # patches can discard owner/services/participants in the cached model.
+    event_data = updated
+
+    StreamEvent({
+        "creationtime": _utcTimestamp(),
+        "data": [event_data],
+        "id": str(uuid.uuid4()),
+        "type": "update"
+    })
+
+    return updated
+
+
+def setMotionAwareRuntimeMotion(area_id, value, source="runtime"):
+    """Set transient motion state and emit only real boolean transitions."""
+    if not isMotionAwareAvailable() or area_id not in motionAwareStoredAreas():
+        return []
+    if not isinstance(value, bool):
+        raise ValueError("motion value must be boolean")
+
+    area = motionAwareStoredArea(area_id)
+    if area.get("enabled") is False:
+        return []
+    enabled_services = [
+        area.get(resource_type, {}).get("enabled", True)
+        if isinstance(area.get(resource_type, {}), dict)
+        else True
+        for resource_type in MOTION_SERVICE_TYPES
+    ]
+    if not any(enabled_services):
+        return []
+
+    with _runtime_lock:
+        current = _runtime_motion.get(area_id)
+        if current is not None and current["motion"] == value:
+            return []
+
+    before = motionAwareSnapshot()
+    with _runtime_lock:
+        _runtime_motion[area_id] = {
+            "motion": value,
+            "changed": _utcTimestamp(),
+            "source": str(source),
+        }
+        _quiet_changed.pop(area_id, None)
+
+    updates = streamMotionAwareTransitions(before)
+    # MotionArea behaviors are keyed by the area configuration resource, so
+    # dispatch them once per real transition after the V2 event is generated.
+    try:
+        from functions.behavior_instance import checkMotionAwareBehaviorInstances
+        checkMotionAwareBehaviorInstances(area_id, value)
+    except Exception as err:
+        # A malformed/legacy behavior must not break MotionAware state or SSE.
+        logging.warning("MotionAware behavior dispatch failed: %s", err)
+    logging.info(
+        "MotionAware runtime area=%s motion=%s source=%s updates=%s",
+        area_id,
+        value,
+        source,
+        len(updates),
+    )
+    return updates
+
+
+def motionAwareSnapshot():
+    """Capture transition-relevant MotionAware state."""
+    if not isMotionAwareAvailable():
+        return {}
+
+    try:
+        resources = v2MotionAwareResources()
+    except Exception as err:
+        logging.warning(
+            "Unable to snapshot MotionAware state: %s",
+            err
+        )
+        return {}
+
+    snapshot = {}
+
+    for resource_type in MOTION_SERVICE_TYPES:
+        for resource in resources[resource_type]:
+            motion = resource.get("motion", {})
+
+            snapshot[(resource_type, resource["id"])] = (
+                bool(motion.get("motion", False)),
+                bool(motion.get("motion_valid", False)),
+            )
+
+    return snapshot
+
+
+def streamMotionAwareTransitions(before):
+    """Emit V2 updates only when aggregate area motion changes."""
+    if not before:
+        return []
+
+    if not isMotionAwareAvailable():
+        return []
+
+    try:
+        resources = v2MotionAwareResources()
+    except Exception as err:
+        logging.warning(
+            "Unable to build MotionAware transition: %s",
+            err
+        )
+        return []
+
+    updates = []
+
+    for resource_type in MOTION_SERVICE_TYPES:
+        for resource in resources[resource_type]:
+            key = (resource_type, resource["id"])
+
+            if key not in before:
+                continue
+
+            motion = resource.get("motion", {})
+
+            after = (
+                bool(motion.get("motion", False)),
+                bool(motion.get("motion_valid", False)),
+            )
+
+            if before[key] == after:
+                continue
+
+            updates.append(resource)
+
+    if not updates:
+        return []
+
+    _streamMotionAwareResources("update", updates)
+
+    return updates

--- a/BridgeEmulator/motionAwareConfig.py
+++ b/BridgeEmulator/motionAwareConfig.py
@@ -1,0 +1,193 @@
+"""Canonical MotionAware configuration keys and safe readers.
+
+The persisted representation intentionally lives below ``config.motion_aware``.
+Live RF/motion state is not part of this schema and must never be written here.
+This module has no dependency on the runtime object graph, which makes it safe
+to use while config.yaml is being loaded and migrated.
+"""
+
+MOTION_AWARE_KEY = "motion_aware"
+LEGACY_MOTION_AWARE_KEYS = ("motionAware", "motionaware")
+AREAS_KEY = "areas"
+
+MOTION_AREA_CONFIGURATION = "motion_area_configuration"
+CONVENIENCE_AREA_MOTION = "convenience_area_motion"
+SECURITY_AREA_MOTION = "security_area_motion"
+MOTION_AREA_CANDIDATE = "motion_area_candidate"
+
+MOTION_SERVICE_TYPES = (
+    CONVENIENCE_AREA_MOTION,
+    SECURITY_AREA_MOTION,
+)
+SERVED_MOTION_RESOURCE_TYPES = (
+    MOTION_AREA_CONFIGURATION,
+    *MOTION_SERVICE_TYPES,
+)
+
+DEFAULT_AREA_ENABLED = True
+DEFAULT_SERVICE_ENABLED = True
+DEFAULT_SENSITIVITY = 2
+MAX_SENSITIVITY = 4
+DEFAULT_HEALTH = "healthy"
+VALID_HEALTH = ("healthy", "unhealthy")
+VALID_GROUP_TYPES = ("bridge_home", "room", "zone")
+
+
+def normalize_motion_aware_config(config):
+    """Normalize only the MotionAware container and return ``(changed, issues)``.
+
+    A missing key remains missing. This is important: config presence is not a
+    capability flag. MotionAware availability is derived separately from the
+    bridge profile. Unknown fields are retained for forward compatibility.
+    Malformed container values are replaced with an empty, inert area map.
+    """
+    if not isinstance(config, dict):
+        raise TypeError("bridge config must be a dictionary")
+
+    changed = False
+    issues = []
+
+    # Older experimental builds used camel-case container names.  Migrate
+    # them once into the canonical diyHue key instead of silently stranding
+    # persisted areas or reading two competing sources of truth.
+    legacy_values = [
+        config[key]
+        for key in LEGACY_MOTION_AWARE_KEYS
+        if key in config
+    ]
+    if MOTION_AWARE_KEY not in config and legacy_values:
+        config[MOTION_AWARE_KEY] = legacy_values[0]
+        changed = True
+    for key in LEGACY_MOTION_AWARE_KEYS:
+        if key in config:
+            del config[key]
+            changed = True
+            if len(legacy_values) > 1:
+                issues.append("multiple legacy MotionAware keys; first value retained")
+
+    if MOTION_AWARE_KEY not in config:
+        return changed, issues
+
+    motion_aware = config.get(MOTION_AWARE_KEY)
+
+    if not isinstance(motion_aware, dict):
+        config[MOTION_AWARE_KEY] = {AREAS_KEY: {}}
+        return True, ["motion_aware must be an object; reset to an empty area map"]
+
+    if AREAS_KEY not in motion_aware:
+        motion_aware[AREAS_KEY] = {}
+        changed = True
+    elif not isinstance(motion_aware[AREAS_KEY], dict):
+        motion_aware[AREAS_KEY] = {}
+        changed = True
+        issues.append("motion_aware.areas must be an object; reset to empty")
+
+    return changed, issues
+
+
+def get_motion_aware_areas(config, create=False):
+    """Return the canonical area map without leaking malformed containers."""
+    if not isinstance(config, dict):
+        return {}
+
+    motion_aware = config.get(MOTION_AWARE_KEY)
+    if not isinstance(motion_aware, dict):
+        if not create:
+            return {}
+        motion_aware = {}
+        config[MOTION_AWARE_KEY] = motion_aware
+
+    areas = motion_aware.get(AREAS_KEY)
+    if not isinstance(areas, dict):
+        if not create:
+            return {}
+        areas = {}
+        motion_aware[AREAS_KEY] = areas
+
+    return areas
+
+
+def get_stored_area(config, area_id):
+    """Return one valid stored area object or an empty read-only fallback."""
+    area = get_motion_aware_areas(config).get(area_id)
+    return area if isinstance(area, dict) else {}
+
+
+def read_bool(mapping, key, default):
+    """Read a real JSON boolean, preserving ``False`` and rejecting 0/1."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if isinstance(value, bool) else default
+
+
+def read_int(mapping, key, default, minimum=None, maximum=None):
+    """Read an integer without accepting bool (a Python int subclass)."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    if minimum is not None and value < minimum:
+        return default
+    if maximum is not None and value > maximum:
+        return default
+    return value
+
+
+def read_nonempty_string(mapping, key, default):
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if isinstance(value, str) and value.strip() else default
+
+
+def read_health(mapping, key="health", default=DEFAULT_HEALTH):
+    """Read the two health enum values understood by Hue's MotionArea model."""
+    if not isinstance(mapping, dict):
+        return default
+    value = mapping.get(key)
+    return value if value in VALID_HEALTH else default
+
+
+def read_resource_reference(value, allowed_types):
+    """Return a normalized V2 resource reference or ``None``."""
+    if not isinstance(value, dict):
+        return None
+    rid = value.get("rid")
+    rtype = value.get("rtype")
+    if not isinstance(rid, str) or not rid or rtype not in allowed_types:
+        return None
+    return {"rid": rid, "rtype": rtype}
+
+
+def read_participants(value):
+    """Return canonical participant records, or ``None`` if malformed.
+
+    Participant health is server-owned runtime metadata. Persisted legacy
+    health is accepted only when it is a non-empty string; otherwise the
+    canonical default is used.
+    """
+    if not isinstance(value, list):
+        return None
+
+    result = []
+    seen = set()
+    for participant in value:
+        if not isinstance(participant, dict):
+            return None
+        resource = read_resource_reference(
+            participant.get("resource"),
+            (MOTION_AREA_CANDIDATE,),
+        )
+        if resource is None or resource["rid"] in seen:
+            return None
+        seen.add(resource["rid"])
+        status = participant.get("status")
+        health = read_health(status)
+        result.append({
+            "resource": resource,
+            "status": {"health": health},
+        })
+
+    return result

--- a/BridgeEmulator/services/eventStreamer.py
+++ b/BridgeEmulator/services/eventStreamer.py
@@ -1,11 +1,27 @@
 import logManager
-from flask import Response, stream_with_context, Blueprint
+from flask import Response, stream_with_context, Blueprint, request
 import json
 from time import sleep, time
 import HueObjects
 
 logging = logManager.logger.get_logger(__name__)
 stream = Blueprint('stream', __name__)
+
+
+def _json_default(value):
+    """Serialize legacy event payloads containing Hue model objects."""
+    get_v2 = getattr(value, "getV2Api", None)
+    if callable(get_v2):
+        return get_v2()
+
+    object_id = getattr(value, "id_v2", None)
+    if object_id is not None:
+        return {
+            "rid": object_id,
+            "rtype": "light" if value.__class__.__name__ == "Light" else "device",
+        }
+
+    return str(value)
 
 def messageBroker():
     # Events are retained in a bounded sequence history.
@@ -17,8 +33,13 @@ def messageBroker():
 @stream.route('/eventstream/clip/v2')
 def streamV2Events():
     def generate():
-        # Each client tracks its own position in the event history.
-        last_seq = HueObjects.EventStreamSequence()
+        # Resume only when the client explicitly supplies an SSE cursor.
+        # Replaying an arbitrary history on a fresh connection resurrects
+        # resources which were already deleted in the client's local graph.
+        try:
+            last_seq = int(request.headers.get("Last-Event-ID", ""))
+        except (TypeError, ValueError):
+            last_seq = HueObjects.EventStreamSequence()
         last_heartbeat = time()
 
         yield ": hi\n\n"
@@ -34,7 +55,7 @@ def streamV2Events():
 
                 yield (
                     f"id: {seq}\n"
-                    f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+                    f"data: {json.dumps(payload, separators=(',', ':'), default=_json_default)}\n\n"
                 )
 
                 last_seq = seq
@@ -47,5 +68,6 @@ def streamV2Events():
 
     return Response(
         stream_with_context(generate()),
-        mimetype='text/event-stream; charset=utf-8'
+        content_type="text/event-stream; charset=utf-8",
+        headers={"Cache-Control": "no-cache"},
     )

--- a/tests/test_bridge_profile.py
+++ b/tests/test_bridge_profile.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+import unittest
+
+
+BRIDGE_EMULATOR = pathlib.Path(__file__).parents[1] / "BridgeEmulator"
+sys.path.insert(0, str(BRIDGE_EMULATOR))
+
+from functions.core import (  # noqa: E402
+    bridgeIdentity,
+    bridgeReportedApiversion,
+    bridgeReportedSwversion,
+    staticConfig,
+)
+
+
+class BridgeProfileTests(unittest.TestCase):
+    def test_default_profile_remains_classic(self):
+        identity = bridgeIdentity({})
+        self.assertEqual(identity["profile"], "classic")
+        self.assertEqual(identity["modelid"], "BSB002")
+        self.assertIsNone(identity["apiversion"])
+        self.assertEqual(staticConfig({})["modelid"], "BSB002")
+
+    def test_pro_profile_is_explicit_and_data_driven(self):
+        config = {"bridge_profile": "pro", "apiversion": "1.75.0", "swversion": "1975104000"}
+        identity = bridgeIdentity(config)
+        self.assertEqual(identity["profile"], "pro")
+        self.assertEqual(identity["modelid"], "BSB003")
+        self.assertEqual(bridgeReportedApiversion(config), "1.78.0")
+        self.assertEqual(bridgeReportedSwversion(config), "2071442000")
+        self.assertEqual(staticConfig(config)["modelid"], "BSB003")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_motion_aware_behavior.py
+++ b/tests/test_motion_aware_behavior.py
@@ -1,0 +1,127 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+import uuid
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+EMULATOR = ROOT / "BridgeEmulator"
+sys.path.insert(0, str(EMULATOR))
+
+
+class FakeGroup:
+    type = "Room"
+
+    def __init__(self):
+        self.id_v2 = "group-v2"
+        self.name = "Test room"
+        self.actions = []
+        self.state = {"any_on": False}
+
+    def setV1Action(self, action):
+        self.actions.append(action)
+
+
+class FakeScene:
+    id_v2 = "scene-v2"
+
+    def __init__(self):
+        self.calls = 0
+
+    def activate(self, _transition):
+        self.calls += 1
+
+
+class FakeInstance:
+    enabled = True
+    id_v2 = "behavior-v2"
+
+    def __init__(self, area_id, group_id):
+        self.configuration = {
+            "source": {
+                "rtype": "motion_area_configuration",
+                "rid": area_id,
+            },
+            "motion": {
+                "motion_service": {
+                    "rid": "service-v2",
+                    "rtype": "convenience_area_motion",
+                },
+                "where": [{
+                    "group": {
+                        "rtype": "room",
+                        "rid": str(uuid.uuid5(uuid.NAMESPACE_URL, group_id + "room")),
+                    }
+                }],
+                "when": {
+                    "timeslots": [{
+                        "start_time": {"time": {"hour": 0, "minute": 0}},
+                        "on_motion": {
+                            "recall_single": [{
+                                "action": {
+                                    "recall": {"rtype": "scene", "rid": "scene-v2"}
+                                }
+                            }]
+                        },
+                        "on_no_motion": {"recall_single": [{"action": "all_off"}]},
+                    }]
+                },
+            },
+        }
+
+
+def load_module(group, instance, scene):
+    old = {key: sys.modules.get(key) for key in ("configManager", "logManager")}
+    config_manager = types.ModuleType("configManager")
+    config_manager.bridgeConfig = types.SimpleNamespace(yaml_config={
+        "groups": {"1": group},
+        "scenes": {"1": scene},
+        "behavior_instance": {instance.id_v2: instance},
+    })
+    log_manager = types.ModuleType("logManager")
+    log_manager.logger = types.SimpleNamespace(get_logger=lambda _name: types.SimpleNamespace(
+        info=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+        debug=lambda *_args, **_kwargs: None,
+    ))
+    sys.modules.update({"configManager": config_manager, "logManager": log_manager})
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "behavior_under_test", EMULATOR / "functions" / "behavior_instance.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, value in old.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+class MotionAwareBehaviorTests(unittest.TestCase):
+    def test_motion_area_true_recalls_configured_scene(self):
+        group = FakeGroup()
+        scene = FakeScene()
+        area_id = "area-v2"
+        instance = FakeInstance(area_id, group.id_v2)
+        module = load_module(group, instance, scene)
+        self.assertEqual(module.checkMotionAwareBehaviorInstances(area_id, True), 1)
+        self.assertEqual(scene.calls, 1)
+
+    def test_motion_area_false_executes_no_motion_action(self):
+        group = FakeGroup()
+        scene = FakeScene()
+        area_id = "area-v2"
+        instance = FakeInstance(area_id, group.id_v2)
+        module = load_module(group, instance, scene)
+        self.assertEqual(module.checkMotionAwareBehaviorInstances(area_id, False), 1)
+        # No delay is configured, so the daemon action is observable immediately.
+        self.assertEqual(group.actions, [{"on": False}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_motion_aware_config.py
+++ b/tests/test_motion_aware_config.py
@@ -1,0 +1,123 @@
+import copy
+import pathlib
+import sys
+import unittest
+
+
+BRIDGE_EMULATOR = pathlib.Path(__file__).parents[1] / "BridgeEmulator"
+sys.path.insert(0, str(BRIDGE_EMULATOR))
+
+from motionAwareConfig import (  # noqa: E402
+    get_motion_aware_areas,
+    normalize_motion_aware_config,
+    read_bool,
+    read_int,
+    read_health,
+    read_participants,
+    read_resource_reference,
+)
+
+
+class MotionAwareConfigTests(unittest.TestCase):
+    def test_missing_config_does_not_enable_or_mutate_feature(self):
+        config = {"bridge_profile": "classic"}
+        before = copy.deepcopy(config)
+        self.assertEqual(normalize_motion_aware_config(config), (False, []))
+        self.assertEqual(config, before)
+        self.assertEqual(get_motion_aware_areas(config), {})
+
+    def test_malformed_containers_become_inert_and_idempotent(self):
+        for malformed in (None, False, 0, "enabled", []):
+            with self.subTest(malformed=malformed):
+                config = {"motion_aware": malformed}
+                changed, issues = normalize_motion_aware_config(config)
+                self.assertTrue(changed)
+                self.assertTrue(issues)
+                self.assertEqual(config["motion_aware"], {"areas": {}})
+                self.assertEqual(
+                    normalize_motion_aware_config(config),
+                    (False, []),
+                )
+
+    def test_missing_areas_is_added_without_losing_unknown_fields(self):
+        config = {"motion_aware": {"future_field": {"x": 1}}}
+        self.assertEqual(normalize_motion_aware_config(config), (True, []))
+        self.assertEqual(config["motion_aware"]["areas"], {})
+        self.assertEqual(config["motion_aware"]["future_field"], {"x": 1})
+
+    def test_legacy_container_is_migrated_to_canonical_key(self):
+        config = {"motionAware": {"areas": {"old": {}}}}
+        changed, issues = normalize_motion_aware_config(config)
+        self.assertTrue(changed)
+        self.assertEqual(issues, [])
+        self.assertNotIn("motionAware", config)
+        areas = get_motion_aware_areas(config, create=True)
+        areas["new"] = {"enabled": False}
+        self.assertEqual(
+            config["motion_aware"],
+            {"areas": {"old": {}, "new": {"enabled": False}}},
+        )
+
+    def test_boolean_reader_preserves_false_and_rejects_ints(self):
+        self.assertFalse(read_bool({"enabled": False}, "enabled", True))
+        self.assertTrue(read_bool({}, "enabled", True))
+        self.assertTrue(read_bool({"enabled": None}, "enabled", True))
+        self.assertTrue(read_bool({"enabled": 0}, "enabled", True))
+
+    def test_integer_reader_preserves_zero_and_rejects_bool(self):
+        self.assertEqual(read_int({"value": 0}, "value", 2, 0, 4), 0)
+        self.assertEqual(read_int({"value": False}, "value", 2, 0, 4), 2)
+        self.assertEqual(read_int({"value": 5}, "value", 2, 0, 4), 2)
+        self.assertEqual(read_int({"value": None}, "value", 2, 0, 4), 2)
+
+    def test_resource_reference_validation(self):
+        self.assertEqual(
+            read_resource_reference(
+                {"rid": "abc", "rtype": "room"}, ("room",)
+            ),
+            {"rid": "abc", "rtype": "room"},
+        )
+        for malformed in (
+            None,
+            {},
+            {"rid": "", "rtype": "room"},
+            {"rid": "abc", "rtype": "device"},
+        ):
+            self.assertIsNone(read_resource_reference(malformed, ("room",)))
+
+    def test_participant_validation_is_canonical_and_non_mutating(self):
+        source = [{
+            "resource": {"rid": "candidate-1", "rtype": "motion_area_candidate"},
+            "status": {"health": "unhealthy"},
+            "unknown": "ignored in API mapping",
+        }]
+        before = copy.deepcopy(source)
+        self.assertEqual(
+            read_participants(source),
+            [{
+                "resource": {
+                    "rid": "candidate-1",
+                    "rtype": "motion_area_candidate",
+                },
+                    "status": {"health": "unhealthy"},
+            }],
+        )
+        self.assertEqual(source, before)
+
+    def test_health_accepts_only_hue_enum(self):
+        self.assertEqual(read_health({"health": "healthy"}), "healthy")
+        self.assertEqual(read_health({"health": "unhealthy"}), "unhealthy")
+        self.assertEqual(read_health({"health": "degraded"}), "healthy")
+        self.assertEqual(read_health({"health": None}), "healthy")
+
+    def test_participant_validation_rejects_duplicates_and_malformed(self):
+        participant = {
+            "resource": {"rid": "same", "rtype": "motion_area_candidate"}
+        }
+        self.assertIsNone(read_participants([participant, participant]))
+        self.assertIsNone(read_participants([{"resource": None}]))
+        self.assertIsNone(read_participants(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_motion_aware_runtime.py
+++ b/tests/test_motion_aware_runtime.py
@@ -1,0 +1,333 @@
+import copy
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+import uuid
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+EMULATOR = ROOT / "BridgeEmulator"
+sys.path.insert(0, str(EMULATOR))
+
+
+class SaveSpy:
+    def __init__(self, yaml_config):
+        self.yaml_config = yaml_config
+        self.saves = []
+
+    def save_config(self, **kwargs):
+        self.saves.append(kwargs)
+
+
+class FakeDevice:
+    def __init__(self, identifier, reachable=True):
+        self.id_v2 = identifier
+        self.group_v1 = "lights"
+        self.protocol = "mqtt"
+        self.protocol_cfg = {"state_topic": f"zigbee2mqtt/{identifier}"}
+        self.reachable = reachable
+
+    def getDevice(self):
+        return {
+            "id": self.id_v2,
+            "services": [],
+            "state": {"reachable": self.reachable},
+        }
+
+    def firstElement(self):
+        return types.SimpleNamespace(state={"reachable": self.reachable})
+
+
+class FakeRoom:
+    type = "Room"
+
+    def __init__(self, identifier, devices):
+        self.id_v2 = identifier
+        self.name = "Test room"
+        self.lights = list(devices)
+        self.sensors = []
+
+    def getV2Room(self):
+        return {
+            "id": str(uuid.uuid5(uuid.NAMESPACE_URL, self.id_v2 + "room")),
+            "type": "room",
+        }
+
+
+def load_module(config, events):
+    """Load motionAware.py with an isolated, in-memory diyHue graph."""
+    old_modules = {
+        key: sys.modules.get(key)
+        for key in ("configManager", "logManager", "HueObjects", "functions", "functions.core")
+    }
+
+    config_manager = types.ModuleType("configManager")
+    config_manager.bridgeConfig = SaveSpy(config)
+    logger = types.SimpleNamespace(
+        get_logger=lambda _name: types.SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+        )
+    )
+    log_manager = types.ModuleType("logManager")
+    log_manager.logger = logger
+    hue_objects = types.ModuleType("HueObjects")
+    hue_objects.StreamEvent = events.append
+    functions = types.ModuleType("functions")
+    core = types.ModuleType("functions.core")
+    core.bridgeIdentity = lambda value: {
+        "profile": "pro" if value.get("bridge_profile") == "pro" else "classic"
+    }
+
+    sys.modules.update({
+        "configManager": config_manager,
+        "logManager": log_manager,
+        "HueObjects": hue_objects,
+        "functions": functions,
+        "functions.core": core,
+    })
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "motion_aware_under_test", EMULATOR / "functions" / "motionAware.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module._test_save_spy = config_manager.bridgeConfig
+        return module
+    finally:
+        for key, value in old_modules.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+class MotionAwareRuntimeTests(unittest.TestCase):
+    def make_graph(self, profile="pro", areas=None, device_count=7):
+        devices = [FakeDevice(f"device-{index}") for index in range(device_count)]
+        room = FakeRoom("room-1", devices)
+        config = {
+            "config": {
+                "bridge_profile": profile,
+                "motion_aware": {"areas": areas if areas is not None else {}},
+            },
+            "device": {
+                device.id_v2: device for device in devices
+            },
+            "groups": {"1": room},
+        }
+        return config, room, devices
+
+    def payload(self, module, room, devices, count=3):
+        return {
+            "name": "Entry area",
+            "group": {"rid": room.getV2Room()["id"], "rtype": "room"},
+            "participants": [
+                {"resource": module.v2MotionAreaCandidateService(device)}
+                for device in devices[:count]
+            ],
+        }
+
+    def test_capability_is_profile_not_config_presence(self):
+        config, _room, _devices = self.make_graph(profile="classic")
+        events = []
+        module = load_module(config, events)
+        self.assertFalse(module.isMotionAwareAvailable())
+        self.assertEqual(module.v2MotionAwareRooms(), [])
+        self.assertEqual(module.v2MotionAwareResources()["motion_area_configuration"], [])
+
+    def test_create_subset_persists_and_gets_complete_graph(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        self.assertEqual(created["type"], "motion_area_configuration")
+        self.assertEqual(len(created["participants"]), 3)
+        area_id = created["id"]
+        stored = config["config"]["motion_aware"]["areas"][area_id]
+        self.assertEqual(len(stored["participants"]), 3)
+        self.assertTrue(stored["enabled"])
+        self.assertTrue(module._test_save_spy.saves)
+        resources = module.v2MotionAwareResources()
+        self.assertEqual(len(resources["motion_area_configuration"]), 1)
+        self.assertEqual(len(resources["convenience_area_motion"]), 1)
+        self.assertEqual(len(resources["security_area_motion"]), 1)
+        self.assertEqual(
+            resources["convenience_area_motion"][0]["owner"]["rid"], area_id
+        )
+        self.assertTrue(all(event["data"][0]["type"] for event in events))
+
+    def test_false_and_zero_survive_update_and_resource_render(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        _area_id, convenience_id, _security_id = module.v2MotionAreaServiceIds(area_id)
+        updated_area = module.updateMotionAwareResource(
+            "motion_area_configuration", area_id, {"enabled": False}
+        )
+        updated_service = module.updateMotionAwareResource(
+            "convenience_area_motion",
+            convenience_id,
+            {"enabled": False, "sensitivity": {"sensitivity": 0}},
+        )
+        self.assertFalse(updated_area["enabled"])
+        self.assertFalse(updated_service["enabled"])
+        self.assertEqual(updated_service["sensitivity"]["sensitivity"], 0)
+        self.assertFalse(
+            config["config"]["motion_aware"]["areas"][area_id]["enabled"]
+        )
+        self.assertEqual(
+            config["config"]["motion_aware"]["areas"][area_id]
+            ["convenience_area_motion"]["sensitivity"],
+            0,
+        )
+        self.assertEqual(events[-1]["data"][0], updated_service)
+
+    def test_disabled_area_does_not_emit_runtime_motion(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        module.updateMotionAwareResource(
+            "motion_area_configuration", area_id, {"enabled": False}
+        )
+        before = len(events)
+        self.assertEqual(module.setMotionAwareRuntimeMotion(area_id, True), [])
+        self.assertEqual(len(events), before)
+
+    def test_quiet_changed_is_stable_and_runtime_only(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        _area_id, convenience_id, _security_id = module.v2MotionAreaServiceIds(area_id)
+        first = module.findMotionAwareResource(
+            "convenience_area_motion", convenience_id
+        )["motion"]
+        second = module.findMotionAwareResource(
+            "convenience_area_motion", convenience_id
+        )["motion"]
+        self.assertEqual(
+            first["motion_report"]["changed"],
+            second["motion_report"]["changed"],
+        )
+        self.assertTrue(module.setMotionAwareRuntimeMotion(area_id, True))
+        self.assertEqual(module.setMotionAwareRuntimeMotion(area_id, True), [])
+        resource = module.findMotionAwareResource(
+            "convenience_area_motion", convenience_id
+        )
+        self.assertTrue(resource["motion"]["motion"])
+        self.assertNotIn("runtime", config["config"]["motion_aware"])
+
+    def test_persisted_area_remains_visible_when_participant_unreachable(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        devices[1].reachable = False
+
+        # Existing areas retain their complete graph and expose participant
+        # health rather than disappearing when a light temporarily drops.
+        resources = module.v2MotionAwareResources()
+        self.assertEqual(len(resources["motion_area_configuration"]), 1)
+        participants = resources["motion_area_configuration"][0]["participants"]
+        self.assertEqual(len(participants), 3)
+        self.assertEqual(participants[1]["status"]["health"], "unhealthy")
+        self.assertEqual(
+            len(module.motionAwareCandidates()), 6,
+            "unreachable candidates remain resolvable only through persisted areas",
+        )
+
+    def test_malformed_stored_area_does_not_crash_or_expose_ghost(self):
+        config, room, _devices = self.make_graph(areas={})
+        events = []
+        module = load_module(config, events)
+        area_id, _convenience_id, _security_id = module.v2MotionAreaIds(room)
+        config["config"]["motion_aware"]["areas"][area_id] = None
+        resources = module.v2MotionAwareResources()
+        self.assertEqual(resources["motion_area_configuration"], [])
+
+    def test_delete_clears_area_and_runtime(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        module.setMotionAwareRuntimeMotion(area_id, True)
+        self.assertTrue(module.deleteMotionAwareArea(area_id))
+        self.assertNotIn(area_id, config["config"]["motion_aware"]["areas"])
+        self.assertIsNone(module.motionAwareRuntimeState(area_id))
+        self.assertEqual(module.v2MotionAwareResources()["motion_area_configuration"], [])
+
+    def test_create_rejects_dangling_or_duplicate_candidates(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        payload = self.payload(module, room, devices)
+        payload["participants"][2] = copy.deepcopy(payload["participants"][0])
+        with self.assertRaises(ValueError):
+            module.createMotionAwareArea(payload)
+        payload = self.payload(module, room, devices)
+        payload["participants"][2]["resource"]["rid"] = "missing"
+        with self.assertRaises(ValueError):
+            module.createMotionAwareArea(payload)
+
+    def test_multiple_subset_areas_have_distinct_stable_ids_and_reservations(self):
+        config, room, devices = self.make_graph(device_count=7)
+        events = []
+        module = load_module(config, events)
+        first = module.createMotionAwareArea(self.payload(module, room, devices[:3]))
+        second = module.createMotionAwareArea(self.payload(module, room, devices[3:6]))
+        self.assertNotEqual(first["id"], second["id"])
+        self.assertEqual(
+            first["id"],
+            module.newMotionAreaId(first["group"], [
+                item["resource"]["rid"] for item in first["participants"]
+            ]),
+        )
+        self.assertEqual(len(module.v2MotionAwareResources()["motion_area_configuration"]), 2)
+        reused = self.payload(module, room, devices[2:5])
+        with self.assertRaises(ValueError):
+            module.createMotionAwareArea(reused)
+
+    def test_create_rejects_dangling_group_reference(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        payload = self.payload(module, room, devices)
+        payload["group"] = {"rid": "missing-room", "rtype": "room"}
+        with self.assertRaises(ValueError):
+            module.createMotionAwareArea(payload)
+
+    def test_configuration_update_validates_group_and_unknown_fields(self):
+        config, room, devices = self.make_graph()
+        events = []
+        module = load_module(config, events)
+        created = module.createMotionAwareArea(self.payload(module, room, devices))
+        area_id = created["id"]
+        updated = module.updateMotionAwareResource(
+            "motion_area_configuration",
+            area_id,
+            {"id": area_id, "group": created["group"]},
+        )
+        self.assertEqual(updated["group"], created["group"])
+        with self.assertRaises(ValueError):
+            module.updateMotionAwareResource(
+                "motion_area_configuration", area_id, {"future": True}
+            )
+        with self.assertRaises(ValueError):
+            module.updateMotionAwareResource(
+                "motion_area_configuration", area_id, {"id": "other"}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Connects Hue-created MotionAware behavior instances to diyHue’s existing behavior executor.

## Scope
- resolve MotionAware `motion.where` group/light targets
- select current Hue timeslot actions
- execute scene recall and no-motion/off-delay actions
- invalidate delayed actions on new transitions
- accept nested stock Hue `motion.where` serialization
- ignore malformed/dangling targets safely

## Tests
MotionAware behavior tests pass (2/2); Python compilation and diff checks pass.

This is a stacked follow-up to the config, profile, resource, and SSE PRs.