### PR TITLE
Fix Docker Python bootstrap dependencies

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -22,7 +22,7 @@ RUN apt update \
         openssl nmap psmisc iproute2 bluez bluetooth libcoap3-bin faketime \
     && curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages \
     && python3 -m pip install -r requirements.txt --no-cache-dir --break-system-packages --ignore-installed \
-    && python3 -m pip uninstall -y pip setuptools wheel \
+    && python3 -m pip uninstall -y pip setuptools wheel --break-system-packages \
     && apt purge -y python3-dev gcc \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*

--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -18,11 +18,11 @@ COPY requirements.txt ./
 # pulls python3-typeguard, whose postinst segfaults under QEMU (linux/arm64 CI).
 RUN apt update \
     && apt install --no-install-recommends -y \
-        curl unzip python3-minimal python3-dev gcc \
+        ca-certificates curl unzip python3-minimal python3-dev gcc \
         openssl nmap psmisc iproute2 bluez bluetooth libcoap3-bin faketime \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages \
-    && pip3 install -r requirements.txt --no-cache-dir --break-system-packages --ignore-installed \
-    && pip3 uninstall -y pip setuptools wheel \
+    && curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages \
+    && python3 -m pip install -r requirements.txt --no-cache-dir --break-system-packages --ignore-installed \
+    && python3 -m pip uninstall -y pip setuptools wheel \
     && apt purge -y python3-dev gcc \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem
The current image build fails before tests with missing CA certificates and `pip3: not found`.

## Fix
- install `ca-certificates` before HTTPS downloads
- fail fast on get-pip download errors
- invoke pip through `python3 -m pip`, which is stable across Debian/Python layouts

## Evidence
CI failure: `curl: (77) error setting certificate file` followed by `/bin/sh: 1: pip3: not found`.
No application/runtime code is changed.